### PR TITLE
feat(c1): refresh/logout with Redis-backed sessions and token rotation

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -25,7 +25,6 @@
         "@types/bcrypt": "^6.0.0",
         "@types/express": "^5.0.3",
         "@types/jest": "^30.0.0",
-        "@types/jsonwebtoken": "^9.0.10",
         "@types/morgan": "^1.9.10",
         "@types/node": "^24.3.0",
         "@typescript-eslint/eslint-plugin": "^8.41.0",
@@ -110,18 +109,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/core/node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@babel/core/node_modules/semver": {
@@ -1396,9 +1383,9 @@
       }
     },
     "node_modules/@jest/console": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.1.1.tgz",
-      "integrity": "sha512-f7TGqR1k4GtN5pyFrKmq+ZVndesiwLU33yDpJIGMS9aW+j6hKjue7ljeAdznBsH9kAnxUWe2Y+Y3fLV/FJt3gA==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.1.2.tgz",
+      "integrity": "sha512-BGMAxj8VRmoD0MoA/jo9alMXSRoqW8KPeqOfEo1ncxnRLatTBCpRoOwlwlEMdudp68Q6WSGwYrrLtTGOh8fLzw==",
       "dev": true,
       "dependencies": {
         "@jest/types": "30.0.5",
@@ -1413,16 +1400,16 @@
       }
     },
     "node_modules/@jest/core": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.1.1.tgz",
-      "integrity": "sha512-3ncU9peZ3D2VdgRkdZtUceTrDgX5yiDRwAFjtxNfU22IiZrpVWlv/FogzDLYSJQptQGfFo3PcHK86a2oG6WUGg==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.1.2.tgz",
+      "integrity": "sha512-iSLOojkYgM7Lw0FF5egecZh+CiLWe4xICM3WOMjFbewhbWn+ixEoPwY7oK9jSCnLLphMFAjussXp7CE3tHa5EA==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "30.1.1",
+        "@jest/console": "30.1.2",
         "@jest/pattern": "30.0.1",
-        "@jest/reporters": "30.1.1",
-        "@jest/test-result": "30.1.1",
-        "@jest/transform": "30.1.1",
+        "@jest/reporters": "30.1.2",
+        "@jest/test-result": "30.1.2",
+        "@jest/transform": "30.1.2",
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "ansi-escapes": "^4.3.2",
@@ -1431,18 +1418,18 @@
         "exit-x": "^0.2.2",
         "graceful-fs": "^4.2.11",
         "jest-changed-files": "30.0.5",
-        "jest-config": "30.1.1",
+        "jest-config": "30.1.2",
         "jest-haste-map": "30.1.0",
         "jest-message-util": "30.1.0",
         "jest-regex-util": "30.0.1",
         "jest-resolve": "30.1.0",
-        "jest-resolve-dependencies": "30.1.1",
-        "jest-runner": "30.1.1",
-        "jest-runtime": "30.1.1",
-        "jest-snapshot": "30.1.1",
+        "jest-resolve-dependencies": "30.1.2",
+        "jest-runner": "30.1.2",
+        "jest-runtime": "30.1.2",
+        "jest-snapshot": "30.1.2",
         "jest-util": "30.0.5",
         "jest-validate": "30.1.0",
-        "jest-watcher": "30.1.1",
+        "jest-watcher": "30.1.2",
         "micromatch": "^4.0.8",
         "pretty-format": "30.0.5",
         "slash": "^3.0.0"
@@ -1469,12 +1456,12 @@
       }
     },
     "node_modules/@jest/environment": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.1.1.tgz",
-      "integrity": "sha512-yWHbU+3j7ehQE+NRpnxRvHvpUhoohIjMePBbIr8lfe0cWVb0WeTf80DNux1GPJa18CDHiIU5DtksGUfxcDE+Rw==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.1.2.tgz",
+      "integrity": "sha512-N8t1Ytw4/mr9uN28OnVf0SYE2dGhaIxOVYcwsf9IInBKjvofAjbFRvedvBBlyTYk2knbJTiEjEJ2PyyDIBnd9w==",
       "dev": true,
       "dependencies": {
-        "@jest/fake-timers": "30.1.1",
+        "@jest/fake-timers": "30.1.2",
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "jest-mock": "30.0.5"
@@ -1484,22 +1471,22 @@
       }
     },
     "node_modules/@jest/expect": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.1.1.tgz",
-      "integrity": "sha512-3vHIHsF+qd3D8FU2c7U5l3rg1fhDwAYcGyHyZAi94YIlTwcJ+boNhRyJf373cl4wxbOX+0Q7dF40RTrTFTSuig==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.1.2.tgz",
+      "integrity": "sha512-tyaIExOwQRCxPCGNC05lIjWJztDwk2gPDNSDGg1zitXJJ8dC3++G/CRjE5mb2wQsf89+lsgAgqxxNpDLiCViTA==",
       "dev": true,
       "dependencies": {
-        "expect": "30.1.1",
-        "jest-snapshot": "30.1.1"
+        "expect": "30.1.2",
+        "jest-snapshot": "30.1.2"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.1.1.tgz",
-      "integrity": "sha512-5YUHr27fpJ64dnvtu+tt11ewATynrHkGYD+uSFgRr8V2eFJis/vEXgToyLwccIwqBihVfz9jwio+Zr1ab1Zihw==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.1.2.tgz",
+      "integrity": "sha512-HXy1qT/bfdjCv7iC336ExbqqYtZvljrV8odNdso7dWK9bSeHtLlvwWWC3YSybSPL03Gg5rug6WLCZAZFH72m0A==",
       "dev": true,
       "dependencies": {
         "@jest/get-type": "30.1.0"
@@ -1509,9 +1496,9 @@
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.1.1.tgz",
-      "integrity": "sha512-fK/25dNgBNYPw3eLi2CRs57g1H04qBAFNMsUY3IRzkfx/m4THe0E1zF+yGQBOMKKc2XQVdc9EYbJ4hEm7/2UtA==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.1.2.tgz",
+      "integrity": "sha512-Beljfv9AYkr9K+ETX9tvV61rJTY706BhBUtiaepQHeEGfe0DbpvUA5Z3fomwc5Xkhns6NWrcFDZn+72fLieUnA==",
       "dev": true,
       "dependencies": {
         "@jest/types": "30.0.5",
@@ -1535,13 +1522,13 @@
       }
     },
     "node_modules/@jest/globals": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.1.1.tgz",
-      "integrity": "sha512-NNUUkHT2TU/xztZl6r1UXvJL+zvCwmZsQDmK69fVHHcB9fBtlu3FInnzOve/ZoyKnWY8JXWJNT+Lkmu1+ubXUA==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.1.2.tgz",
+      "integrity": "sha512-teNTPZ8yZe3ahbYnvnVRDeOjr+3pu2uiAtNtrEsiMjVPPj+cXd5E/fr8BL7v/T7F31vYdEHrI5cC/2OoO/vM9A==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "30.1.1",
-        "@jest/expect": "30.1.1",
+        "@jest/environment": "30.1.2",
+        "@jest/expect": "30.1.2",
         "@jest/types": "30.0.5",
         "jest-mock": "30.0.5"
       },
@@ -1563,15 +1550,15 @@
       }
     },
     "node_modules/@jest/reporters": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.1.1.tgz",
-      "integrity": "sha512-Hb2Bq80kahOC6Sv2waEaH1rEU6VdFcM6WHaRBWQF9tf30+nJHxhl/Upbgo9+25f0mOgbphxvbwSMjSgy9gW/FA==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.1.2.tgz",
+      "integrity": "sha512-8Jd7y3DUFBn8dG/bNJ2blmaJmT2Up74WAXkUJsbL0OuEZHDRRMnS4JmRtLArW2d0H5k8RDdhNN7j70Ki16Zr5g==",
       "dev": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "30.1.1",
-        "@jest/test-result": "30.1.1",
-        "@jest/transform": "30.1.1",
+        "@jest/console": "30.1.2",
+        "@jest/test-result": "30.1.2",
+        "@jest/transform": "30.1.2",
         "@jest/types": "30.0.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "@types/node": "*",
@@ -1617,9 +1604,9 @@
       }
     },
     "node_modules/@jest/snapshot-utils": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.1.1.tgz",
-      "integrity": "sha512-TkVBc9wuN22TT8hESRFmjjg/xIMu7z0J3UDYtIRydzCqlLPTB7jK1DDBKdnTUZ4zL3z3rnPpzV6rL1Uzh87sXg==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.1.2.tgz",
+      "integrity": "sha512-vHoMTpimcPSR7OxS2S0V1Cpg8eKDRxucHjoWl5u4RQcnxqQrV3avETiFpl8etn4dqxEGarBeHbIBety/f8mLXw==",
       "dev": true,
       "dependencies": {
         "@jest/types": "30.0.5",
@@ -1646,12 +1633,12 @@
       }
     },
     "node_modules/@jest/test-result": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.1.1.tgz",
-      "integrity": "sha512-bMdj7fNu8iZuBPSnbVir5ezvWmVo4jrw7xDE+A33Yb3ENCoiJK9XgOLgal+rJ9XSKjsL7aPUMIo87zhN7I5o2w==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.1.2.tgz",
+      "integrity": "sha512-mpKFr8DEpfG5aAfQYA5+3KneAsRBXhF7zwtwqT4UeYBckoOPD1MzVxU6gDHwx4gRB7I1MKL6owyJzr8QRq402Q==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "30.1.1",
+        "@jest/console": "30.1.2",
         "@jest/types": "30.0.5",
         "@types/istanbul-lib-coverage": "^2.0.6",
         "collect-v8-coverage": "^1.0.2"
@@ -1661,12 +1648,12 @@
       }
     },
     "node_modules/@jest/test-sequencer": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.1.1.tgz",
-      "integrity": "sha512-yruRdLXSA3HYD/MTNykgJ6VYEacNcXDFRMqKVAwlYegmxICUiT/B++CNuhJnYJzKYks61iYnjVsMwbUqmmAYJg==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.1.2.tgz",
+      "integrity": "sha512-v3vawuj2LC0XjpzF4q0pI0ZlQvMBDNqfRZZ2yHqcsGt7JEYsDK2L1WwrybEGlnOaEvnDFML/Y9xWLiW47Dda8A==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "30.1.1",
+        "@jest/test-result": "30.1.2",
         "graceful-fs": "^4.2.11",
         "jest-haste-map": "30.1.0",
         "slash": "^3.0.0"
@@ -1676,9 +1663,9 @@
       }
     },
     "node_modules/@jest/transform": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.1.1.tgz",
-      "integrity": "sha512-PHIA2AbAASBfk6evkNifvmx9lkOSkmvaQoO6VSpuL8+kQqDMHeDoJ7RU3YP1wWAMD7AyQn9UL5iheuFYCC4lqQ==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.1.2.tgz",
+      "integrity": "sha512-UYYFGifSgfjujf1Cbd3iU/IQoSd6uwsj8XHj5DSDf5ERDcWMdJOPTkHWXj4U+Z/uMagyOQZ6Vne8C4nRIrCxqA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
@@ -2100,16 +2087,6 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
-    "node_modules/@types/jsonwebtoken": {
-      "version": "9.0.10",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
-      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
-      "dev": true,
-      "dependencies": {
-        "@types/ms": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -2124,12 +2101,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/ms": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
-      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-      "dev": true
     },
     "node_modules/@types/node": {
       "version": "24.3.0",
@@ -2807,24 +2778,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/ansi-styles/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/ansi-styles/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -2996,12 +2949,12 @@
       }
     },
     "node_modules/babel-jest": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.1.1.tgz",
-      "integrity": "sha512-1bZfC/V03qBCzASvZpNFhx3Ouj6LgOd4KFJm4br/fYOS+tSSvVCE61QmcAVbMTwq/GoB7KN4pzGMoyr9cMxSvQ==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.1.2.tgz",
+      "integrity": "sha512-IQCus1rt9kaSh7PQxLYRY5NmkNrNlU2TpabzwV7T2jljnpdHOcmnYYv8QmE04Li4S3a2Lj8/yXyET5pBarPr6g==",
       "dev": true,
       "dependencies": {
-        "@jest/transform": "30.1.1",
+        "@jest/transform": "30.1.2",
         "@types/babel__core": "^7.20.5",
         "babel-plugin-istanbul": "^7.0.0",
         "babel-preset-jest": "30.0.1",
@@ -3589,17 +3542,21 @@
       }
     },
     "node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
-        "color-name": "1.1.3"
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
       }
     },
     "node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/color-string": {
       "version": "1.9.1",
@@ -3609,6 +3566,19 @@
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -3990,12 +3960,6 @@
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
-    },
-    "node_modules/error-ex/node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
     },
     "node_modules/es-abstract": {
       "version": "1.24.0",
@@ -4605,14 +4569,14 @@
       }
     },
     "node_modules/expect": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-30.1.1.tgz",
-      "integrity": "sha512-OKe7cdic4qbfWd/CcgwJvvCrNX2KWfuMZee9AfJHL1gTYmvqjBjZG1a2NwfhspBzxzlXwsN75WWpKTYfsJpBxg==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.1.2.tgz",
+      "integrity": "sha512-xvHszRavo28ejws8FpemjhwswGj4w/BetHIL8cU49u4sGyXDw2+p3YbeDbj6xzlxi6kWTjIRSTJ+9sNXPnF0Zg==",
       "dev": true,
       "dependencies": {
-        "@jest/expect-utils": "30.1.1",
+        "@jest/expect-utils": "30.1.2",
         "@jest/get-type": "30.1.0",
-        "jest-matcher-utils": "30.1.1",
+        "jest-matcher-utils": "30.1.2",
         "jest-message-util": "30.1.0",
         "jest-mock": "30.0.5",
         "jest-util": "30.0.5"
@@ -5400,9 +5364,10 @@
       }
     },
     "node_modules/is-arrayish": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
@@ -5896,15 +5861,15 @@
       }
     },
     "node_modules/jest": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-30.1.1.tgz",
-      "integrity": "sha512-yC3JvpP/ZcAZX5rYCtXO/g9k6VTCQz0VFE2v1FpxytWzUqfDtu0XL/pwnNvptzYItvGwomh1ehomRNMOyhCJKw==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.1.2.tgz",
+      "integrity": "sha512-iLreJmUWdANLD2UIbebrXxQqU9jIxv2ahvrBNfff55deL9DtVxm8ZJBLk/kmn0AQ+FyCTrNSlGbMdTgSasldYA==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "30.1.1",
+        "@jest/core": "30.1.2",
         "@jest/types": "30.0.5",
         "import-local": "^3.2.0",
-        "jest-cli": "30.1.1"
+        "jest-cli": "30.1.2"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -5936,14 +5901,14 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.1.1.tgz",
-      "integrity": "sha512-M3Vd4x5wD7eSJspuTvRF55AkOOBndRxgW3gqQBDlFvbH3X+ASdi8jc+EqXEeAFd/UHulVYIlC4XKJABOhLw6UA==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.1.2.tgz",
+      "integrity": "sha512-pyqgRv00fPbU3QBjN9I5QRd77eCWA19NA7BLgI1veFvbUIFpeDCKbnG1oyRr6q5/jPEW2zDfqZ/r6fvfE85vrA==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "30.1.1",
-        "@jest/expect": "30.1.1",
-        "@jest/test-result": "30.1.1",
+        "@jest/environment": "30.1.2",
+        "@jest/expect": "30.1.2",
+        "@jest/test-result": "30.1.2",
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "chalk": "^4.1.2",
@@ -5951,10 +5916,10 @@
         "dedent": "^1.6.0",
         "is-generator-fn": "^2.1.0",
         "jest-each": "30.1.0",
-        "jest-matcher-utils": "30.1.1",
+        "jest-matcher-utils": "30.1.2",
         "jest-message-util": "30.1.0",
-        "jest-runtime": "30.1.1",
-        "jest-snapshot": "30.1.1",
+        "jest-runtime": "30.1.2",
+        "jest-snapshot": "30.1.2",
         "jest-util": "30.0.5",
         "p-limit": "^3.1.0",
         "pretty-format": "30.0.5",
@@ -5967,18 +5932,18 @@
       }
     },
     "node_modules/jest-cli": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.1.1.tgz",
-      "integrity": "sha512-xm9llxuh5OoI5KZaYzlMhklryHBwg9LZy/gEaaMlXlxb+cZekGNzukU0iblbDo3XOBuN6N0CgK4ykgNRYSEb6g==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.1.2.tgz",
+      "integrity": "sha512-Q7H6GGo/0TBB8Mhm3Ab7KKJHn6GeMVff+/8PVCQ7vXXahvr5sRERnNbxuVJAMiVY2JQm5roA7CHYOYlH+gzmUg==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "30.1.1",
-        "@jest/test-result": "30.1.1",
+        "@jest/core": "30.1.2",
+        "@jest/test-result": "30.1.2",
         "@jest/types": "30.0.5",
         "chalk": "^4.1.2",
         "exit-x": "^0.2.2",
         "import-local": "^3.2.0",
-        "jest-config": "30.1.1",
+        "jest-config": "30.1.2",
         "jest-util": "30.0.5",
         "jest-validate": "30.1.0",
         "yargs": "^17.7.2"
@@ -5999,28 +5964,28 @@
       }
     },
     "node_modules/jest-config": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.1.1.tgz",
-      "integrity": "sha512-xuPGUGDw+9fPPnGmddnLnHS/mhKUiJOW7K65vErYmglEPKq65NKwSRchkQ7iv6gqjs2l+YNEsAtbsplxozdOWg==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.1.2.tgz",
+      "integrity": "sha512-gCuBeE/cksjQ3e1a8H4YglZJuVPcnLZQK9jC70E6GbkHNQKPasnOO+r9IYdsUbAekb6c7eVRR8laGLMF06gMqg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/get-type": "30.1.0",
         "@jest/pattern": "30.0.1",
-        "@jest/test-sequencer": "30.1.1",
+        "@jest/test-sequencer": "30.1.2",
         "@jest/types": "30.0.5",
-        "babel-jest": "30.1.1",
+        "babel-jest": "30.1.2",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
         "deepmerge": "^4.3.1",
         "glob": "^10.3.10",
         "graceful-fs": "^4.2.11",
-        "jest-circus": "30.1.1",
+        "jest-circus": "30.1.2",
         "jest-docblock": "30.0.1",
-        "jest-environment-node": "30.1.1",
+        "jest-environment-node": "30.1.2",
         "jest-regex-util": "30.0.1",
         "jest-resolve": "30.1.0",
-        "jest-runner": "30.1.1",
+        "jest-runner": "30.1.2",
         "jest-util": "30.0.5",
         "jest-validate": "30.1.0",
         "micromatch": "^4.0.8",
@@ -6050,9 +6015,9 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.1.1.tgz",
-      "integrity": "sha512-LUU2Gx8EhYxpdzTR6BmjL1ifgOAQJQELTHOiPv9KITaKjZvJ9Jmgigx01tuZ49id37LorpGc9dPBPlXTboXScw==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.1.2.tgz",
+      "integrity": "sha512-4+prq+9J61mOVXCa4Qp8ZjavdxzrWQXrI80GNxP8f4tkI2syPuPrJgdRPZRrfUTRvIoUwcmNLbqEJy9W800+NQ==",
       "dev": true,
       "dependencies": {
         "@jest/diff-sequences": "30.0.1",
@@ -6093,13 +6058,13 @@
       }
     },
     "node_modules/jest-environment-node": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.1.1.tgz",
-      "integrity": "sha512-IaMoaA6saxnJimqCppUDqKck+LKM0Jg+OxyMUIvs1yGd2neiC22o8zXo90k04+tO+49OmgMR4jTgM5e4B0S62Q==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.1.2.tgz",
+      "integrity": "sha512-w8qBiXtqGWJ9xpJIA98M0EIoq079GOQRQUyse5qg1plShUCQ0Ek1VTTcczqKrn3f24TFAgFtT+4q3aOXvjbsuA==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "30.1.1",
-        "@jest/fake-timers": "30.1.1",
+        "@jest/environment": "30.1.2",
+        "@jest/fake-timers": "30.1.2",
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "jest-mock": "30.0.5",
@@ -6148,14 +6113,14 @@
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.1.1.tgz",
-      "integrity": "sha512-SuH2QVemK48BNTqReti6FtjsMPFsSOD/ZzRxU1TttR7RiRsRSe78d03bb4Cx6D4bQC/80Q8U4VnaaAH9FlbZ9w==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.1.2.tgz",
+      "integrity": "sha512-7ai16hy4rSbDjvPTuUhuV8nyPBd6EX34HkBsBcBX2lENCuAQ0qKCPb/+lt8OSWUa9WWmGYLy41PrEzkwRwoGZQ==",
       "dev": true,
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
-        "jest-diff": "30.1.1",
+        "jest-diff": "30.1.2",
         "pretty-format": "30.0.5"
       },
       "engines": {
@@ -6242,28 +6207,28 @@
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.1.1.tgz",
-      "integrity": "sha512-tRtaaoH8Ws1Gn1o/9pedt19dvVgr81WwdmvJSP9Ow3amOUOP2nN9j94u5jC9XlIfa2Q1FQKIWWQwL4ajqsjCGQ==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.1.2.tgz",
+      "integrity": "sha512-HJjyoaedY4wrwda+eqvgjbwFykrAnQEmhuT0bMyOV3GQIyLPcunZcjfkm77Zr11ujwl34ySdc4qYnm7SG75TjA==",
       "dev": true,
       "dependencies": {
         "jest-regex-util": "30.0.1",
-        "jest-snapshot": "30.1.1"
+        "jest-snapshot": "30.1.2"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-runner": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.1.1.tgz",
-      "integrity": "sha512-ATe6372SOfJvCRExtCAr06I4rGujwFdKg44b6i7/aOgFnULwjxzugJ0Y4AnG+jeSeQi8dU7R6oqLGmsxRUbErQ==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.1.2.tgz",
+      "integrity": "sha512-eu9AzpDY/QV+7NuMg6fZMpQ7M24cBkl5dyS1Xj7iwDPDriOmLUXR8rLojESibcIX+sCDTO4KvUeaxWCH1fbTvg==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "30.1.1",
-        "@jest/environment": "30.1.1",
-        "@jest/test-result": "30.1.1",
-        "@jest/transform": "30.1.1",
+        "@jest/console": "30.1.2",
+        "@jest/environment": "30.1.2",
+        "@jest/test-result": "30.1.2",
+        "@jest/transform": "30.1.2",
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "chalk": "^4.1.2",
@@ -6271,14 +6236,14 @@
         "exit-x": "^0.2.2",
         "graceful-fs": "^4.2.11",
         "jest-docblock": "30.0.1",
-        "jest-environment-node": "30.1.1",
+        "jest-environment-node": "30.1.2",
         "jest-haste-map": "30.1.0",
         "jest-leak-detector": "30.1.0",
         "jest-message-util": "30.1.0",
         "jest-resolve": "30.1.0",
-        "jest-runtime": "30.1.1",
+        "jest-runtime": "30.1.2",
         "jest-util": "30.0.5",
-        "jest-watcher": "30.1.1",
+        "jest-watcher": "30.1.2",
         "jest-worker": "30.1.0",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
@@ -6288,17 +6253,17 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.1.1.tgz",
-      "integrity": "sha512-7sOyR0Oekw4OesQqqBHuYJRB52QtXiq0NNgLRzVogiMSxKCMiliUd6RrXHCnG5f12Age/ggidCBiQftzcA9XKw==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.1.2.tgz",
+      "integrity": "sha512-zU02si+lAITgyRmVRgJn/AB4cnakq8+o7bP+5Z+N1A4r2mq40zGbmrg3UpYQWCkeim17tx8w1Tnmt6tQ6y9PGA==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "30.1.1",
-        "@jest/fake-timers": "30.1.1",
-        "@jest/globals": "30.1.1",
+        "@jest/environment": "30.1.2",
+        "@jest/fake-timers": "30.1.2",
+        "@jest/globals": "30.1.2",
         "@jest/source-map": "30.0.1",
-        "@jest/test-result": "30.1.1",
-        "@jest/transform": "30.1.1",
+        "@jest/test-result": "30.1.2",
+        "@jest/transform": "30.1.2",
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "chalk": "^4.1.2",
@@ -6311,7 +6276,7 @@
         "jest-mock": "30.0.5",
         "jest-regex-util": "30.0.1",
         "jest-resolve": "30.1.0",
-        "jest-snapshot": "30.1.1",
+        "jest-snapshot": "30.1.2",
         "jest-util": "30.0.5",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
@@ -6320,19 +6285,10 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jest-runtime/node_modules/strip-bom": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-snapshot": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.1.1.tgz",
-      "integrity": "sha512-7/iBEzoJqEt2TjkQY+mPLHP8cbPhLReZVkkxjTMzIzoTC4cZufg7HzKo/n9cIkXKj2LG0x3mmBHsZto+7TOmFg==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.1.2.tgz",
+      "integrity": "sha512-4q4+6+1c8B6Cy5pGgFvjDy/Pa6VYRiGu0yQafKkJ9u6wQx4G5PqI2QR6nxTl43yy7IWsINwz6oT4o6tD12a8Dg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.27.4",
@@ -6340,17 +6296,17 @@
         "@babel/plugin-syntax-jsx": "^7.27.1",
         "@babel/plugin-syntax-typescript": "^7.27.1",
         "@babel/types": "^7.27.3",
-        "@jest/expect-utils": "30.1.1",
+        "@jest/expect-utils": "30.1.2",
         "@jest/get-type": "30.1.0",
-        "@jest/snapshot-utils": "30.1.1",
-        "@jest/transform": "30.1.1",
+        "@jest/snapshot-utils": "30.1.2",
+        "@jest/transform": "30.1.2",
         "@jest/types": "30.0.5",
         "babel-preset-current-node-syntax": "^1.1.0",
         "chalk": "^4.1.2",
-        "expect": "30.1.1",
+        "expect": "30.1.2",
         "graceful-fs": "^4.2.11",
-        "jest-diff": "30.1.1",
-        "jest-matcher-utils": "30.1.1",
+        "jest-diff": "30.1.2",
+        "jest-matcher-utils": "30.1.2",
         "jest-message-util": "30.1.0",
         "jest-util": "30.0.5",
         "pretty-format": "30.0.5",
@@ -6420,12 +6376,12 @@
       }
     },
     "node_modules/jest-watcher": {
-      "version": "30.1.1",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.1.1.tgz",
-      "integrity": "sha512-CrAQ73LlaS6KGQQw6NBi71g7qvP7scy+4+2c0jKX6+CWaYg85lZiig5nQQVTsS5a5sffNPL3uxXnaE9d7v9eQg==",
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.1.2.tgz",
+      "integrity": "sha512-MtoGuEgqsBM8Jkn52oEj+mXLtF94+njPlHI5ydfduZL5MHrTFr14ZG1CUX1xAbY23dbSZCCEkEPhBM3cQd12Jg==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "30.1.1",
+        "@jest/test-result": "30.1.2",
         "@jest/types": "30.0.5",
         "@types/node": "*",
         "ansi-escapes": "^4.3.2",
@@ -6524,15 +6480,15 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
       "bin": {
         "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -6860,12 +6816,12 @@
       "dev": true
     },
     "node_modules/log-update/node_modules/is-fullwidth-code-point": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz",
-      "integrity": "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
       "dev": true,
       "dependencies": {
-        "get-east-asian-width": "^1.0.0"
+        "get-east-asian-width": "^1.3.1"
       },
       "engines": {
         "node": ">=18"
@@ -8534,6 +8490,11 @@
         "is-arrayish": "^0.3.1"
       }
     },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -8867,12 +8828,12 @@
       }
     },
     "node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
       "dev": true,
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/strip-final-newline": {
@@ -9115,18 +9076,6 @@
         }
       }
     },
-    "node_modules/ts-jest/node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/ts-jest/node_modules/type-fest": {
       "version": "4.41.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
@@ -9238,6 +9187,36 @@
         "json5": "^1.0.2",
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tsconfig/node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/tsconfig/node_modules/strip-json-comments": {

--- a/server/package.json
+++ b/server/package.json
@@ -47,7 +47,6 @@
     "@types/bcrypt": "^6.0.0",
     "@types/express": "^5.0.3",
     "@types/jest": "^30.0.0",
-    "@types/jsonwebtoken": "^9.0.10",
     "@types/morgan": "^1.9.10",
     "@types/node": "^24.3.0",
     "@typescript-eslint/eslint-plugin": "^8.41.0",

--- a/server/src/config/redis.ts
+++ b/server/src/config/redis.ts
@@ -13,11 +13,15 @@ function getClient(): RedisClientType {
     });
     client.on("error", (e) => {
       // Avoid noisy unhandled errors; health endpoint will report status instead.
-       
+
       console.warn("[redis] client error:", (e as any)?.message || e);
     });
   }
   return client;
+}
+
+export function redisClient() {
+  return getClient();
 }
 
 /** Build a namespaced Redis key: e.g., fr:dev:rate:ip:1.2.3.4 */

--- a/server/src/modules/auth/controller.ts
+++ b/server/src/modules/auth/controller.ts
@@ -1,9 +1,12 @@
 import type { Request, Response } from "express";
 
 import { registerSchema, loginSchema } from "./schemas.js";
-import { signAccessToken, signRefreshToken } from "./tokens.js";
+import { refreshSchema } from "./schemas.js";
+import { persistSession, revokeSession, isSessionActive } from "./sessions.js";
+import { verifyRefresh, signAccessToken, signRefreshToken } from "./tokens.js";
 import { asyncHandler, jsonOk } from "../../utils/http.js";
 import { createUser, findByEmail, toPublicUser, verifyPassword } from "../user/service.js";
+import { findById } from "../user/service.js";
 
 export const register = asyncHandler(async (req: Request, res: Response) => {
   const body = registerSchema.parse(req.body);
@@ -19,6 +22,17 @@ export const register = asyncHandler(async (req: Request, res: Response) => {
   // Auto-login
   const accessToken = signAccessToken({ sub: user.id, role: user.role });
   const refreshToken = signRefreshToken({ sub: user.id });
+
+  // Persist refresh session
+  const rClaims = verifyRefresh(refreshToken);
+  await persistSession({
+    userId: rClaims.sub,
+    jti: rClaims.jti,
+    exp: rClaims.exp,
+    iat: rClaims.iat,
+    ip: req.ip,
+    ua: req.get("user-agent") || null,
+  });
 
   return res.status(201).json({
     user: toPublicUser(user),
@@ -46,8 +60,82 @@ export const login = asyncHandler(async (req: Request, res: Response) => {
   const accessToken = signAccessToken({ sub: user.id, role: user.role });
   const refreshToken = signRefreshToken({ sub: user.id });
 
+  const rClaims = verifyRefresh(refreshToken);
+  await persistSession({
+    userId: rClaims.sub,
+    jti: rClaims.jti,
+    exp: rClaims.exp,
+    iat: rClaims.iat,
+    ip: req.ip,
+    ua: req.get("user-agent") || null,
+  });
+
   jsonOk(res, {
     user: toPublicUser(user),
     tokens: { accessToken, refreshToken },
   });
+});
+
+export const refresh = asyncHandler(async (req: Request, res: Response) => {
+  const { refreshToken } = refreshSchema.parse(req.body);
+
+  // 1) Verify token
+  let claims;
+  try {
+    claims = verifyRefresh(refreshToken);
+  } catch {
+    return res
+      .status(401)
+      .json({ error: { code: "INVALID_REFRESH", message: "Invalid refresh token" } });
+  }
+
+  // 2) Check active session
+  const active = await isSessionActive(claims.sub, claims.jti);
+  if (!active) {
+    return res
+      .status(401)
+      .json({
+        error: { code: "INVALID_REFRESH", message: "Refresh session not found or expired" },
+      });
+  }
+
+  // 3) Rotate: revoke old session, issue new pair
+  await revokeSession(claims.sub, claims.jti);
+
+  const user = await findById(claims.sub);
+  if (!user) {
+    return res
+      .status(401)
+      .json({ error: { code: "INVALID_REFRESH", message: "User no longer exists" } });
+  }
+
+  const accessToken = signAccessToken({ sub: user.id, role: user.role });
+  const newRefreshToken = signRefreshToken({ sub: user.id });
+
+  const newClaims = verifyRefresh(newRefreshToken);
+  await persistSession({
+    userId: newClaims.sub,
+    jti: newClaims.jti,
+    exp: newClaims.exp,
+    iat: newClaims.iat,
+    ip: req.ip,
+    ua: req.get("user-agent") || null,
+  });
+
+  return jsonOk(res, { accessToken, refreshToken: newRefreshToken });
+});
+
+export const logout = asyncHandler(async (req: Request, res: Response) => {
+  const { refreshToken } = refreshSchema.parse(req.body);
+  let claims;
+  try {
+    claims = verifyRefresh(refreshToken);
+  } catch {
+    return res
+      .status(401)
+      .json({ error: { code: "INVALID_REFRESH", message: "Invalid refresh token" } });
+  }
+
+  await revokeSession(claims.sub, claims.jti);
+  return jsonOk(res, { success: true });
 });

--- a/server/src/modules/auth/routes.ts
+++ b/server/src/modules/auth/routes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 
 import { register, login } from "./controller.js";
+import { refresh, logout } from "./controller.js";
 import { rateLimitIP } from "./rateLimit.js";
 
 export const authRouter = Router();
@@ -10,5 +11,11 @@ authRouter.post("/register", register);
 
 // Login: light IP rate limit (5/min)
 authRouter.post("/login", rateLimitIP({ windowMs: 60_000, max: 5 }), login);
+
+// Refresh: rotate token, 10/min per IP
+authRouter.post("/refresh", rateLimitIP({ windowMs: 60_000, max: 10 }), refresh);
+
+// Logout: revoke current session, 30/min per IP
+authRouter.post("/logout", rateLimitIP({ windowMs: 60_000, max: 30 }), logout);
 
 export default authRouter;

--- a/server/src/modules/auth/schemas.ts
+++ b/server/src/modules/auth/schemas.ts
@@ -26,5 +26,10 @@ export const loginSchema = z.object({
   password: z.string().min(1, "Password is required"),
 });
 
+export const refreshSchema = z.object({
+  refreshToken: z.string().min(1, "refreshToken is required"),
+});
+
 export type RegisterInput = z.infer<typeof registerSchema>;
 export type LoginInput = z.infer<typeof loginSchema>;
+export type RefreshInput = z.infer<typeof refreshSchema>;

--- a/server/src/modules/auth/sessions.ts
+++ b/server/src/modules/auth/sessions.ts
@@ -1,0 +1,68 @@
+/** Refresh-session storage in Redis: persist, check, revoke. */
+import type { RedisClientType } from "redis";
+
+import { redisClient, key } from "../../config/redis.js";
+
+function sessionKey(userId: string, jti: string) {
+  return key("sess", userId, jti); // e.g., fr:dev:sess:<uid>:<jti>
+}
+
+function ttlFromExp(exp?: number): number {
+  const now = Math.floor(Date.now() / 1000);
+  const ttl = typeof exp === "number" ? exp - now : 0;
+  return Math.max(ttl, 1);
+}
+
+async function ensureOpen(c: RedisClientType) {
+  if (!c.isOpen) await c.connect();
+}
+
+export async function persistSession(args: {
+  userId: string;
+  jti: string;
+  exp?: number; // seconds since epoch (from JWT)
+  iat?: number; // seconds since epoch (from JWT)
+  ip?: string | null;
+  ua?: string | null;
+}) {
+  const c = redisClient();
+  await ensureOpen(c);
+  const k = sessionKey(args.userId, args.jti);
+  const v = JSON.stringify({
+    uid: args.userId,
+    jti: args.jti,
+    ip: args.ip || null,
+    ua: args.ua || null,
+    iat: args.iat || null,
+    exp: args.exp || null,
+  });
+  await c.set(k, v, { EX: ttlFromExp(args.exp) });
+}
+
+export async function isSessionActive(userId: string, jti: string): Promise<boolean> {
+  const c = redisClient();
+  await ensureOpen(c);
+  const exists = await c.exists(sessionKey(userId, jti));
+  return exists === 1;
+}
+
+export async function revokeSession(userId: string, jti: string): Promise<void> {
+  const c = redisClient();
+  await ensureOpen(c);
+  await c.del(sessionKey(userId, jti));
+}
+
+// (Optional) revoke all for a user — not used yet, but handy later
+export async function revokeAllSessionsForUser(userId: string): Promise<number> {
+  const c = redisClient();
+  await ensureOpen(c);
+  const prefix = key("sess", userId, ""); // fr:dev:sess:<uid>:
+  const iter = c.scanIterator({ MATCH: `${prefix}*`, COUNT: 100 });
+
+  let count = 0;
+  for await (const k of iter as any) {
+    await c.del(k as string);
+    count++;
+  }
+  return count;
+}

--- a/server/src/modules/auth/tokens.ts
+++ b/server/src/modules/auth/tokens.ts
@@ -1,7 +1,7 @@
 /** JWT helpers: sign/verify access & refresh tokens, with rotation support. */
 import { randomUUID } from "crypto";
 
-import jwt, { type JwtPayload } from "jsonwebtoken";
+import jwt, { type JwtPayload, type SignOptions, type Secret } from "jsonwebtoken";
 
 import { env } from "../../config/env.js";
 
@@ -27,25 +27,32 @@ export function newJti(): string {
 export function signAccessToken(input: { sub: string; role: Role; jti?: string }): string {
   const jti = input.jti ?? newJti();
   const payload: Partial<AccessClaims> = { sub: input.sub, role: input.role, type: "access" };
-  return jwt.sign(payload, env.JWT_SECRET, {
+
+  const opts: SignOptions = {
     algorithm: "HS256",
-    expiresIn: env.JWT_ACCESS_TTL, // "15m" works
+    expiresIn: env.JWT_ACCESS_TTL, // "15m"
     issuer: env.JWT_ISS,
     audience: env.JWT_AUD,
     jwtid: jti,
-  });
+  };
+
+  return jwt.sign(payload, env.JWT_SECRET as Secret, opts);
 }
 
 export function signRefreshToken(input: { sub: string; jti?: string }): string {
   const jti = input.jti ?? newJti();
   const payload: Partial<RefreshClaims> = { sub: input.sub, type: "refresh" };
-  return jwt.sign(payload, env.JWT_REFRESH_SECRET || env.JWT_SECRET, {
+
+  const opts: SignOptions = {
     algorithm: "HS256",
-    expiresIn: env.JWT_REFRESH_TTL, // "30d" works
+    expiresIn: env.JWT_REFRESH_TTL, // "30d"
     issuer: env.JWT_ISS,
     audience: env.JWT_AUD,
     jwtid: jti,
-  });
+  };
+
+  const secret: Secret = (env.JWT_REFRESH_SECRET || env.JWT_SECRET) as Secret;
+  return jwt.sign(payload, secret, opts);
 }
 
 export function verifyAccess(token: string): AccessClaims {

--- a/server/src/modules/user/service.ts
+++ b/server/src/modules/user/service.ts
@@ -42,6 +42,11 @@ export async function findByEmail(
   return q.exec();
 }
 
+export async function findById(id: string): Promise<UserDoc | null> {
+  await connectMongo();
+  return User.findById(id).exec();
+}
+
 /** Verify password (requires a doc with passwordHash selected) */
 export async function verifyPassword(plain: string, userWithHash: UserDoc): Promise<boolean> {
   // Will throw if passwordHash wasn't selected

--- a/server/src/types/jsonwebtoken.d.ts
+++ b/server/src/types/jsonwebtoken.d.ts
@@ -1,0 +1,9 @@
+declare module "jsonwebtoken" {
+  export type JwtPayload = any;
+  export type SignOptions = any;
+  export type Secret = any;
+  const jwt: any;
+  export default jwt;
+  export function sign(...args: any[]): any;
+  export function verify(...args: any[]): any;
+}

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,19 +1,21 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ES2022",
-    "moduleResolution": "node",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "rootDir": "src",
     "outDir": "dist",
     "strict": true,
     "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "noImplicitOverride": true,
     "noFallthroughCasesInSwitch": true,
     "newLine": "lf",
-    "sourceMap": true
+    "sourceMap": true,
+    "typeRoots": ["./src/types", "./node_modules/@types"]
   },
   "include": ["src"],
   "exclude": ["test", "**/*.test.ts"]


### PR DESCRIPTION
- Sessions: add Redis-backed refresh sessions with namespaced keys (fr:<env>:sess:<uid>:<jti>)
  - Helpers: persistSession, isSessionActive, revokeSession, revokeAllSessionsForUser
  - Value stores { uid, jti, ip, ua, iat, exp }; TTL derived from refresh token exp
  - Export redisClient() from config for reuse
- Auth routes:
  - POST /auth/refresh: verify refresh JWT (iss/aud/exp), require active session, rotate:
    * revoke old session, mint new access/refresh pair (new jti), persist new session
    * return { accessToken, refreshToken }
  - POST /auth/logout: verify refresh JWT, revoke that session, return { success: true }
  - Existing /auth/register and /auth/login now persist a refresh session on success
- Rate limiting: add light IP limits (refresh 10/min, logout 30/min) alongside existing login limiter
- Types/TS:
  - Use jsonwebtoken v9 typings (with temporary local shim if needed)
  - Minor tsconfig/typing tweaks to keep  green

Acceptance:
- First refresh returns new tokens; reusing the old refresh → 401 INVALID_REFRESH
- Logout revokes the session; subsequent refresh with that token → 401
- Register/Login create a session visible in Redis; rotation updates it

Refs: C1-D
