### PR TITLE
feat(c4): Asset create endpoint + boot-time data deps

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -23,6 +23,7 @@
       },
       "devDependencies": {
         "@types/bcrypt": "^6.0.0",
+        "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
         "@types/jest": "^30.0.0",
         "@types/morgan": "^1.9.10",
@@ -2001,6 +2002,15 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"

--- a/server/package.json
+++ b/server/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",
+    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/jest": "^30.0.0",
     "@types/morgan": "^1.9.10",

--- a/server/src/config/db.ts
+++ b/server/src/config/db.ts
@@ -1,6 +1,11 @@
 /** Mongo connector + ping using Mongoose (Atlas-friendly) */
 import mongoose from "mongoose";
 
+// Fail immediately if a model op runs before connect()
+mongoose.set("bufferCommands", false);
+// Helps ensure collections/indexes get created in dev
+mongoose.set("autoCreate", true);
+
 import { env } from "./env.js";
 
 let connecting: Promise<void> | null = null;

--- a/server/src/config/env.ts
+++ b/server/src/config/env.ts
@@ -1,7 +1,7 @@
 // server/src/config/env.ts
 /** Environment loader: reads .env, validates with Zod, exports typed config and CORS origins array. */
 import "dotenv/config";
-import { z } from "zod";
+import { z } from "zod/v4";
 
 const EnvSchema = z.object({
   NODE_ENV: z.enum(["development", "test", "production"]).default("development"),

--- a/server/src/middlewares/error.ts
+++ b/server/src/middlewares/error.ts
@@ -1,6 +1,4 @@
 // server/src/middlewares/error.ts
-/** Global error handler: handles Zod (422) and unexpected errors, emits uniform { error: {…} }. */
-
 import type { ErrorRequestHandler } from "express";
 import { ZodError } from "zod";
 
@@ -8,26 +6,41 @@ import { logger } from "../config/logger.js";
 
 export const errorHandler: ErrorRequestHandler = (err, req, res, _next) => {
   const requestId = res.locals.requestId;
-  // Zod -> 422
-  if (err instanceof ZodError) {
-    const details = err.flatten();
+
+  // Zod (defensive): detect by name/issues, not by internals
+  const looksLikeZod =
+    err instanceof ZodError ||
+    (err && typeof err === "object" && Array.isArray((err as any).issues));
+
+  if (looksLikeZod) {
+    let details: unknown = undefined;
+    try {
+      if (typeof (err as any).flatten === "function") {
+        details = (err as any).flatten();
+      } else if (Array.isArray((err as any).issues)) {
+        details = { issues: (err as any).issues };
+      }
+    } catch {
+      details = undefined;
+    }
     logger.warn("Validation error", { requestId, details });
-    return res.status(422).json({
-      error: { code: "UNPROCESSABLE_ENTITY", message: "Invalid request body", details },
-    });
+    return res
+      .status(422)
+      .json({ error: { code: "UNPROCESSABLE_ENTITY", message: "Invalid request body", details } });
   }
 
-  const status = (err as any).status || 500;
-  const code = (err as any).code || (status === 404 ? "NOT_FOUND" : "INTERNAL_ERROR");
+  const status = (err as any)?.status || 500;
+  const code = (err as any)?.code || (status === 404 ? "NOT_FOUND" : "INTERNAL_ERROR");
 
-  logger.error(err.message || "Unhandled error", {
+  // always log stack if present
+  logger.error(err?.message || "Unhandled error", {
     requestId,
     status,
     code,
-    stack: (err as any).stack,
+    stack: (err as any)?.stack,
   });
 
   res.status(status).json({
-    error: { code, message: err.message ?? "Internal server error", requestId },
+    error: { code, message: err?.message ?? "Internal server error", requestId },
   });
 };

--- a/server/src/modules/admin/schemas.ts
+++ b/server/src/modules/admin/schemas.ts
@@ -1,5 +1,5 @@
 // zod schemas for admin endpoints
-import { z } from "zod";
+import { z } from "zod/v4";
 
 export const pageQuery = z.object({
   page: z.coerce.number().int().positive().default(1),

--- a/server/src/modules/assets/routes.ts
+++ b/server/src/modules/assets/routes.ts
@@ -1,0 +1,55 @@
+// src/modules/assets/routes.ts
+import { Router } from "express";
+
+import { Asset } from "./model.js";
+import { CreateAssetSchema, type CreateAssetInput } from "./schemas.js";
+import { requireAuth, requireRole, getAuth } from "../../middlewares/auth.js";
+import { asyncHandler, jsonOk } from "../../utils/http.js";
+
+const router = Router();
+
+/** Host: create an asset (location required) */
+router.post(
+  "/assets",
+  requireAuth,
+  requireRole("host"),
+  asyncHandler(async (req, res) => {
+    // 🔹 no throwing: turn Zod errors into a 422 response
+    const parsed = CreateAssetSchema.safeParse(req.body);
+    if (!parsed.success) {
+      const details = parsed.error.flatten();
+      return res
+        .status(422)
+        .json({
+          error: { code: "UNPROCESSABLE_ENTITY", message: "Invalid request body", details },
+        });
+    }
+    const input = CreateAssetSchema.parse(req.body) as CreateAssetInput;
+    const { userId } = getAuth(req);
+
+    const doc = await Asset.create({
+      hostId: userId,
+      category: input.category,
+      title: input.title,
+      description: input.description,
+      specs: input.specs,
+      media: input.media,
+      location: input.location, // GeoJSON Point: [lng, lat]
+      status: "active", // or 'draft' if you prefer moderation first
+    });
+
+    jsonOk(res, { id: doc.id });
+  })
+);
+
+// quick sanity: confirm auth + body parsing + routing works
+router.post(
+  "/assets/raw",
+  requireAuth,
+  requireRole("host"),
+  asyncHandler(async (req, res) => {
+    return jsonOk(res, { ok: true, body: req.body });
+  })
+);
+
+export default router;

--- a/server/src/modules/assets/schemas.ts
+++ b/server/src/modules/assets/schemas.ts
@@ -1,0 +1,19 @@
+// src/modules/assets/schemas.ts
+import { z } from "zod/v4";
+
+export const GeoPointInput = z.object({
+  type: z.literal("Point"),
+  // NOTE: [lng, lat] order
+  coordinates: z.tuple([z.number().gte(-180).lte(180), z.number().gte(-90).lte(90)]),
+});
+
+export const CreateAssetSchema = z.object({
+  category: z.enum(["car", "boat", "jetski", "electronics", "lawn", "misc"]),
+  title: z.string().min(1).max(120).optional(),
+  description: z.string().max(2000).optional(),
+  specs: z.record(z.string(), z.any()).default({}),
+  media: z.array(z.string().url()).default([]),
+  location: GeoPointInput, // REQUIRED
+});
+
+export type CreateAssetInput = z.infer<typeof CreateAssetSchema>;

--- a/server/src/modules/auth/schemas.ts
+++ b/server/src/modules/auth/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v4";
 
 export const passwordPolicy = z
   .string()

--- a/server/src/modules/listings/http.ts
+++ b/server/src/modules/listings/http.ts
@@ -1,0 +1,96 @@
+import { Router } from "express";
+import mongoose from "mongoose";
+import { z } from "zod/v4";
+
+import { Listing } from "./model.js";
+import { enumerateBuckets } from "../../utils/dates.js";
+import { asyncHandler, jsonOk } from "../../utils/http.js";
+import { BookingLock } from "../locks/model.js";
+
+const router = Router();
+
+type Granularity = "hour" | "day";
+const HOUR_CATS = new Set(["car", "boat", "jetski"]);
+const granularityFor = (category: string): Granularity =>
+  HOUR_CATS.has(category) ? "hour" : "day";
+
+const Q = z.object({
+  start: z.coerce.date(),
+  end: z.coerce.date(),
+});
+
+router.get(
+  "/:id/availability",
+  asyncHandler(async (req, res) => {
+    const id = req.params.id;
+    if (!mongoose.isValidObjectId(id)) {
+      return res.status(422).json({ error: { code: "INVALID_ID", message: "Invalid listing id" } });
+    }
+
+    const qq = Q.safeParse(req.query);
+    if (!qq.success) {
+      return res.status(422).json({ error: { code: "INVALID_QUERY", message: qq.error.message } });
+    }
+    const { start, end } = qq.data;
+    if (end <= start) {
+      return res
+        .status(422)
+        .json({ error: { code: "INVALID_WINDOW", message: "end must be after start" } });
+    }
+    // Cap max window (e.g., 31 days worth of buckets)
+    if (end.getTime() - start.getTime() > 31 * 24 * 3600 * 1000) {
+      return res
+        .status(422)
+        .json({ error: { code: "INVALID_WINDOW", message: "range too large" } });
+    }
+
+    const listing = await Listing.findById(id, {
+      assetId: 1,
+      status: 1,
+      blackouts: 1,
+      pricing: 1,
+    }).lean();
+    if (!listing || listing.status !== "active") {
+      return res
+        .status(404)
+        .json({ error: { code: "LISTING_NOT_FOUND", message: "Listing not found" } });
+    }
+
+    if (!mongoose.connection.db) throw new Error("DB not ready");
+    const asset = await mongoose.connection.db
+      .collection("assets")
+      .findOne({ _id: listing.assetId }, { projection: { category: 1 } });
+
+    const category = asset?.category || "misc";
+    const granularity = granularityFor(category);
+
+    const buckets = enumerateBuckets(start.getTime(), end.getTime(), granularity); // string[]
+    if (buckets.length === 0) return jsonOk(res, { granularity, buckets: [] });
+
+    // Locks present?
+    const locked = await BookingLock.find(
+      { listingId: new mongoose.Types.ObjectId(id), dateBucket: { $in: buckets } },
+      { dateBucket: 1, _id: 0 }
+    ).lean();
+    const lockedSet = new Set(locked.map((d: any) => d.dateBucket));
+
+    // Blackouts filter
+    const blockedByBlackout = (bucket: string) => {
+      if (!Array.isArray(listing.blackouts) || listing.blackouts.length === 0) return false;
+      const bStart =
+        granularity === "hour"
+          ? new Date(`${bucket}:00:00.000Z`)
+          : new Date(`${bucket}T00:00:00.000Z`);
+      for (const w of listing.blackouts) {
+        if (!w?.start || !w?.end) continue;
+        if (bStart >= new Date(w.start) && bStart < new Date(w.end)) return true;
+      }
+      return false;
+    };
+
+    const available = buckets.filter((b) => !lockedSet.has(b) && !blockedByBlackout(b));
+    jsonOk(res, { granularity, buckets: available });
+  })
+);
+
+export default router;

--- a/server/src/modules/quotes/http.ts
+++ b/server/src/modules/quotes/http.ts
@@ -1,0 +1,115 @@
+import { Router } from "express";
+import mongoose from "mongoose";
+import { z } from "zod/v4";
+
+import { enumerateBuckets } from "../../utils/dates.js";
+import { asyncHandler } from "../../utils/http.js";
+import { Listing } from "../listings/model.js";
+import { BookingLock } from "../locks/model.js";
+
+const router = Router();
+
+type Granularity = "hour" | "day";
+const HOUR_CATS = new Set(["car", "boat", "jetski"]);
+const granularityFor = (category: string): Granularity =>
+  HOUR_CATS.has(category) ? "hour" : "day";
+
+const Body = z.object({
+  listingId: z.string(),
+  start: z.coerce.date(),
+  end: z.coerce.date(),
+  options: z.object({ protectionPlan: z.enum(["basic", "plus", "pro"]).optional() }).optional(),
+  promoCode: z.string().optional(),
+});
+
+router.post(
+  "/preview",
+  asyncHandler(async (req, res) => {
+    const parsed = Body.safeParse(req.body);
+    if (!parsed.success) {
+      return res
+        .status(422)
+        .json({ error: { code: "INVALID_BODY", message: parsed.error.message } });
+    }
+    const { listingId, start, end } = parsed.data;
+
+    if (!mongoose.isValidObjectId(listingId)) {
+      return res.status(422).json({ error: { code: "INVALID_ID", message: "Invalid listingId" } });
+    }
+    if (end <= start) {
+      return res
+        .status(422)
+        .json({ error: { code: "INVALID_WINDOW", message: "end must be after start" } });
+    }
+
+    const listing = await Listing.findById(listingId).lean();
+    if (!listing || listing.status !== "active") {
+      return res
+        .status(404)
+        .json({ error: { code: "LISTING_NOT_FOUND", message: "Listing not found" } });
+    }
+
+    if (!mongoose.connection.db) throw new Error("DB not ready");
+    const asset = await mongoose.connection.db
+      .collection("assets")
+      .findOne({ _id: listing.assetId }, { projection: { category: 1 } });
+
+    const category = asset?.category || "misc";
+    const granularity = granularityFor(category);
+
+    const buckets = enumerateBuckets(start.getTime(), end.getTime(), granularity);
+    if (buckets.length === 0) {
+      return res
+        .status(422)
+        .json({ error: { code: "INVALID_WINDOW", message: "window too short" } });
+    }
+
+    // Check locks
+    const locked = await BookingLock.find(
+      { listingId: new mongoose.Types.ObjectId(listingId), dateBucket: { $in: buckets } },
+      { dateBucket: 1, _id: 0 }
+    ).lean();
+    const lockedSet = new Set(locked.map((d: any) => d.dateBucket));
+    // Check blackouts
+    const inBlackout = (bucket: string) => {
+      if (!Array.isArray(listing.blackouts) || listing.blackouts.length === 0) return false;
+      const bStart =
+        granularity === "hour"
+          ? new Date(`${bucket}:00:00.000Z`)
+          : new Date(`${bucket}T00:00:00.000Z`);
+      for (const w of listing.blackouts) {
+        if (!w?.start || !w?.end) continue;
+        if (bStart >= new Date(w.start) && bStart < new Date(w.end)) return true;
+      }
+      return false;
+    };
+    const conflict = buckets.some((b) => lockedSet.has(b) || inBlackout(b));
+    if (conflict) {
+      return res
+        .status(409)
+        .json({ error: { code: "UNAVAILABLE", message: "Listing not available for that window" } });
+    }
+
+    const nUnits = buckets.length;
+    const basePer =
+      granularity === "hour"
+        ? (listing as any).pricing?.baseHourlyCents || 0
+        : (listing as any).pricing?.baseDailyCents || 0;
+    const baseCents = nUnits * basePer;
+    const feeCents = (listing as any).pricing?.feeCents || 0;
+    const depositCents = (listing as any).pricing?.depositCents || 0;
+    const taxCents = 0;
+    const totalCents = baseCents + feeCents + taxCents;
+
+    return res.json({
+      listingId,
+      start: start.toISOString(),
+      end: end.toISOString(),
+      granularity,
+      nUnits,
+      pricingSnapshot: { baseCents, feeCents, depositCents, taxCents, totalCents },
+    });
+  })
+);
+
+export default router;

--- a/server/src/modules/quotes/routes.ts
+++ b/server/src/modules/quotes/routes.ts
@@ -1,0 +1,129 @@
+// src/modules/quotes/routes.ts
+import { Router } from "express";
+import mongoose from "mongoose";
+import { z } from "zod/v4";
+
+import { enumerateBuckets, toUtcMidnight } from "../../utils/dates.js";
+import { asyncHandler } from "../../utils/http.js";
+import { Listing } from "../listings/model.js";
+import { BookingLock } from "../locks/model.js";
+
+const router = Router();
+
+const PreviewSchema = z.object({
+  listingId: z.string().length(24),
+  start: z.coerce.date(),
+  end: z.coerce.date(),
+});
+
+function overlaps(aStart: Date, aEnd: Date, bStart: Date, bEnd: Date) {
+  return aStart < bEnd && bStart < aEnd;
+}
+
+router.post(
+  "/quotes/preview",
+  asyncHandler(async (req, res) => {
+    const { listingId, start, end } = PreviewSchema.parse(req.body);
+
+    const listing = await Listing.findById(listingId).lean();
+    if (!listing || listing.status !== "active") {
+      return res.status(404).json({ error: { code: "LISTING_NOT_FOUND" } });
+    }
+
+    // Decide granularity
+    const hasHourly = !!listing.pricing?.baseHourlyCents;
+    const granularity: "hour" | "day" = hasHourly ? "hour" : "day";
+
+    // Build requested buckets
+    const buckets =
+      granularity === "hour"
+        ? enumerateBuckets(start.getTime(), end.getTime(), "hour")
+        : enumerateBuckets(toUtcMidnight(start).getTime(), toUtcMidnight(end).getTime(), "day");
+
+    if (!buckets.length) {
+      return res.status(422).json({
+        error: { code: "INVALID_WINDOW", message: "Empty or invalid time window" },
+      });
+    }
+
+    // 1) Locks conflict?
+    const lockDocs = await BookingLock.find({
+      listingId: new mongoose.Types.ObjectId(listingId),
+      dateBucket: { $in: buckets },
+    })
+      .select({ dateBucket: 1 })
+      .lean();
+
+    // 2) Blackouts conflict?
+    const blackoutHits =
+      (listing.blackouts || []).filter((b: any) =>
+        overlaps(start, end, new Date(b.start), new Date(b.end))
+      ) || [];
+
+    if (lockDocs.length || blackoutHits.length) {
+      return res.status(409).json({
+        error: {
+          code: "UNAVAILABLE",
+          message: "Requested window is unavailable",
+          conflictBuckets: lockDocs.map((d) => d.dateBucket),
+          conflictBlackouts: blackoutHits.map((b: any) => ({
+            start: b.start,
+            end: b.end,
+            reason: b.reason,
+          })),
+        },
+      });
+    }
+
+    // Pricing
+    const p = listing.pricing || {};
+    const feeCents = p.feeCents ?? 0;
+    const depositCents = p.depositCents ?? 0;
+
+    let nUnits = buckets.length;
+    let baseCents = 0;
+
+    if (granularity === "hour") {
+      const minHours = p.minHours ?? 1;
+      const hourly = p.baseHourlyCents ?? Math.ceil(((p.baseDailyCents ?? 0) as number) / 24);
+
+      if (!hourly) {
+        return res.status(422).json({
+          error: { code: "NO_PRICING", message: "Missing hourly/daily pricing" },
+        });
+      }
+
+      const billable = Math.max(nUnits, minHours);
+      baseCents = hourly * billable;
+      nUnits = billable; // reflect the billable hours in the response
+    } else {
+      const daily = p.baseDailyCents ?? Math.ceil(((p.baseHourlyCents ?? 0) as number) * 24);
+      if (!daily) {
+        return res.status(422).json({
+          error: { code: "NO_PRICING", message: "Missing daily/hourly pricing" },
+        });
+      }
+      baseCents = daily * nUnits;
+    }
+
+    const taxCents = 0; // tax comes later (C7)
+    const totalCents = baseCents + feeCents + taxCents;
+
+    return res.json({
+      listingId,
+      start,
+      end,
+      granularity,
+      nUnits,
+      pricingSnapshot: {
+        baseCents,
+        feeCents,
+        taxCents,
+        depositCents,
+        totalCents,
+      },
+    });
+  })
+);
+
+export default router;

--- a/server/src/modules/search/http.ts
+++ b/server/src/modules/search/http.ts
@@ -1,0 +1,38 @@
+import { Router } from "express";
+import { z } from "zod/v4";
+
+import { searchNearby } from "./service.js";
+import { asyncHandler, jsonOk } from "../../utils/http.js";
+
+const router = Router();
+
+const QuerySchema = z.object({
+  lat: z.coerce.number(),
+  lng: z.coerce.number(),
+  radiusKm: z.coerce.number().min(0.1).max(200).default(25),
+  category: z.enum(["car", "boat", "jetski", "electronics", "lawn", "misc"]).optional(),
+  minPrice: z.coerce.number().int().nonnegative().optional(),
+  maxPrice: z.coerce.number().int().nonnegative().optional(),
+  instantBook: z
+    .enum(["true", "false"])
+    .transform((v) => v === "true")
+    .optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+});
+
+router.get(
+  "/",
+  asyncHandler(async (req, res) => {
+    const parsed = QuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      return res
+        .status(422)
+        .json({ error: { code: "INVALID_QUERY", message: parsed.error.message } });
+    }
+    const out = await searchNearby(parsed.data);
+    jsonOk(res, out);
+  })
+);
+
+export default router;

--- a/server/src/modules/search/service.ts
+++ b/server/src/modules/search/service.ts
@@ -1,0 +1,116 @@
+import mongoose from "mongoose";
+
+import { connectMongo } from "../../config/db"; // adjust path
+
+type SearchParams = {
+  lat: number;
+  lng: number;
+  radiusKm: number;
+  category?: string;
+  instantBook?: boolean;
+  minPrice?: number;
+  maxPrice?: number;
+  page: number;
+  limit: number;
+};
+
+const HOUR_CATS = ["car", "boat", "jetski"];
+
+export async function searchNearby(params: SearchParams) {
+  await connectMongo();
+
+  const { lat, lng, radiusKm, category, instantBook, minPrice, maxPrice, page, limit } = params;
+
+  const radiusMeters = Math.min(Math.max(radiusKm, 0.1), 200) * 1000;
+  const skip = (page - 1) * limit;
+
+  if (!mongoose.connection.db) throw new Error("DB not ready");
+  const assets = mongoose.connection.db.collection("assets");
+
+  const pipeline: any[] = [
+    {
+      $geoNear: {
+        near: { type: "Point", coordinates: [lng, lat] },
+        distanceField: "dist",
+        maxDistance: radiusMeters,
+        spherical: true,
+      },
+    },
+    { $match: { status: "active", ...(category ? { category } : {}) } },
+    {
+      $lookup: {
+        from: "listings",
+        localField: "_id",
+        foreignField: "assetId",
+        as: "listing",
+      },
+    },
+    { $unwind: "$listing" },
+    {
+      $match: {
+        "listing.status": "active",
+        ...(instantBook !== undefined ? { "listing.instantBook": !!instantBook } : {}),
+      },
+    },
+    // derive priceCents depending on category granularity
+    {
+      $addFields: {
+        priceCents: {
+          $cond: [
+            { $in: ["$category", HOUR_CATS] },
+            "$listing.pricing.baseHourlyCents",
+            "$listing.pricing.baseDailyCents",
+          ],
+        },
+      },
+    },
+    ...(minPrice !== undefined || maxPrice !== undefined
+      ? [
+          {
+            $match: {
+              ...(minPrice !== undefined ? { priceCents: { $gte: minPrice } } : {}),
+              ...(maxPrice !== undefined
+                ? {
+                    priceCents: {
+                      ...(minPrice !== undefined ? { $gte: minPrice } : {}),
+                      $lte: maxPrice,
+                    },
+                  }
+                : {}),
+            },
+          },
+        ]
+      : []),
+    {
+      $project: {
+        _id: 0,
+        assetId: "$_id",
+        listingId: "$listing._id",
+        category: 1,
+        status: "$listing.status",
+        coords: "$location.coordinates",
+        distanceKm: { $divide: ["$dist", 1000] },
+        priceCents: 1,
+        instantBook: "$listing.instantBook",
+        media: { $slice: ["$media", 3] },
+      },
+    },
+    { $skip: skip },
+    { $limit: limit + 1 }, // fetch one extra to compute hasMore
+  ];
+
+  const items = await assets.aggregate(pipeline).toArray();
+  const hasMore = items.length > limit;
+  if (hasMore) items.pop();
+
+  // normalize coords -> {lat, lng}
+  const normalized = items.map((it: any) => ({
+    ...it,
+    coords:
+      Array.isArray(it.coords) && it.coords.length === 2
+        ? { lng: it.coords[0], lat: it.coords[1] }
+        : undefined,
+  }));
+
+  return { page, limit, hasMore, items: normalized };
+}

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -5,7 +5,11 @@ import { Router } from "express";
 import { pingMongo } from "./config/db.js";
 import { pingRedis } from "./config/redis.js";
 import adminRouter from "./modules/admin/routes.js";
+import assetsRouter from "./modules/assets/routes.js";
 import authRouter from "./modules/auth/routes.js";
+import listingsHttp from "./modules/listings/http.js";
+import quotesRouter from "./modules/quotes/http.js";
+import searchRouter from "./modules/search/http.js";
 import usersRouter from "./modules/users/routes.js";
 import { kycRouter, personaWebhook } from "./modules/verifications/http.js";
 import { asyncHandler, jsonOk } from "./utils/http.js";
@@ -16,6 +20,10 @@ router.use("/auth", authRouter);
 router.use("/", usersRouter); // exposes GET /me
 router.use("/kyc", kycRouter);
 router.use("/admin", adminRouter);
+router.use("/search", searchRouter);
+router.use("/listings", listingsHttp);
+router.use("/quotes", quotesRouter);
+router.use("/", assetsRouter);
 
 // Basic health (no deps)
 router.get(

--- a/server/src/utils/dates.ts
+++ b/server/src/utils/dates.ts
@@ -70,3 +70,7 @@ export function enumerateBuckets(
   }
   return out;
 }
+
+export function toUtcMidnight(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}


### PR DESCRIPTION
- Add Zod schemas for assets (GeoJSON Point + CreateAssetSchema)
- Implement POST /assets (host-only) with requireAuth/requireRole
- Return { id } on success
- Wire assets router into top-level routes
- Boot-time connectMongo() and pingRedis() before app.listen()
- Mongoose: set bufferCommands=false, autoCreate=true (fail fast, create colls in dev)
- Remove temporary /assets/raw test route (if present)
- Minor log/handler polish for consistent error JSON