### PR TITLE
feat(cli): add end-to-end dev CLI for assets/listings/quotes/bookings…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
 .DS_Store
+
+# dev CLI session cache
+server/tmp/

--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,9 @@
     "format:write": "prettier --write .",
     "test": "jest --passWithNoTests",
     "prepare": "husky",
-    "db:sync-indexes": "tsx scripts/sync-indexes.ts"
+    "db:sync-indexes": "tsx scripts/sync-indexes.ts",
+    "cli": "tsx scripts/cli.ts",
+    "test:health": "npm run cli -- health"
   },
   "keywords": [],
   "author": "",

--- a/server/scripts/cli.ts
+++ b/server/scripts/cli.ts
@@ -1,0 +1,295 @@
+import "dotenv/config";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+import mongoose from "mongoose";
+
+const BASE = process.env.BASE_URL || "http://localhost:3001";
+const TMP_DIR = path.join(process.cwd(), "tmp");
+const SESSION_FILE = path.join(TMP_DIR, "session.json");
+
+type Role = "renter" | "host";
+type Session = {
+  renter?: { token: string; id: string; email?: string };
+  host?: { token: string; id: string; email?: string };
+};
+
+function ensureTmp() {
+  if (!fs.existsSync(TMP_DIR)) fs.mkdirSync(TMP_DIR, { recursive: true });
+}
+function readSession(): Session {
+  ensureTmp();
+  if (!fs.existsSync(SESSION_FILE)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(SESSION_FILE, "utf8"));
+  } catch {
+    return {};
+  }
+}
+function writeSession(s: Session) {
+  ensureTmp();
+  fs.writeFileSync(SESSION_FILE, JSON.stringify(s, null, 2));
+}
+
+async function http(method: string, path: string, body?: any, token?: string) {
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  let json: any;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    json = { raw: text };
+  }
+  if (!res.ok) {
+    const msg = json?.error?.message || `${res.status} ${res.statusText}`;
+    const err: any = new Error(msg);
+    err.status = res.status;
+    err.body = json;
+    throw err;
+  }
+  return json;
+}
+
+function arg(name: string, fallback?: string) {
+  const idx = process.argv.indexOf(`--${name}`);
+  if (idx >= 0 && process.argv[idx + 1]) return process.argv[idx + 1];
+  return fallback;
+}
+function flag(name: string) {
+  return process.argv.includes(`--${name}`);
+}
+
+function isId24(v?: string) {
+  return !!v && /^[0-9a-fA-F]{24}$/.test(v);
+}
+
+async function cmdHealth() {
+  const a = await http("GET", "/health");
+  console.log(JSON.stringify(a, null, 2));
+}
+
+async function cmdLogin() {
+  const email = arg("email");
+  const password = arg("password") || "Str0ng@Pass!";
+  const as: Role = (arg("as") as Role) || "renter";
+  if (!email) throw new Error("Missing --email");
+  const res = await http("POST", "/auth/login", { email, password });
+  const token = res?.tokens?.accessToken;
+  const id = res?.user?.id;
+  if (!token || !id) throw new Error("Login response missing token/id");
+  const sess = readSession();
+  sess[as] = { token, id, email };
+  writeSession(sess);
+  console.log(JSON.stringify({ role: as, id, email, tokenLen: token.length }, null, 2));
+}
+
+async function cmdMe() {
+  const as: Role = (arg("as") as Role) || "renter";
+  const sess = readSession();
+  const token = sess[as]?.token;
+  if (!token)
+    throw new Error(`No session for role ${as}. Run: npm run cli -- login --email <e> --as ${as}`);
+  const me = await http("GET", "/users/me", undefined, token);
+  console.log(JSON.stringify(me, null, 2));
+}
+
+async function cmdAssetCreate() {
+  const as: Role = (arg("as") as Role) || "host";
+  const sess = readSession();
+  const token = sess[as]?.token;
+  if (!token) throw new Error(`No session for role ${as}. Login first.`);
+  const category = arg("category", "car");
+  const title = arg("title", "Civic LX");
+  const description = arg("description", "Solid commuter");
+  const lng = Number(arg("lng", "-95.9345"));
+  const lat = Number(arg("lat", "41.2565"));
+
+  const body = {
+    category,
+    title,
+    description,
+    specs: { color: "blue" },
+    media: [],
+    location: { type: "Point", coordinates: [lng, lat] },
+  };
+  const out = await http("POST", "/assets", body, token);
+  console.log(JSON.stringify(out, null, 2));
+}
+
+async function cmdListingEnsure() {
+  // ensures a listing for (assetId, hostId). Uses Mongo directly to avoid extra HTTP code.
+  const assetId = arg("asset");
+  const hostId = arg("host"); // optional; if missing, derive from host session /me
+  const sess = readSession();
+  let host = hostId;
+  if (!host) {
+    // derive from /me with host token
+    const token = sess.host?.token;
+    if (!token) throw new Error("No host session; pass --host <id> or login as host");
+    const me: any = await http("GET", "/users/me", undefined, token);
+    host = me?.user?.id;
+  }
+  if (!isId24(assetId) || !isId24(host)) {
+    throw new Error("Invalid --asset or --host (must be 24 hex)");
+  }
+
+  await mongoose.connect(process.env.MONGO_URI as string);
+  const db = mongoose.connection.db!;
+  const existing = await db
+    .collection("listings")
+    .findOne(
+      {
+        assetId: new mongoose.Types.ObjectId(assetId!),
+        hostId: new mongoose.Types.ObjectId(host!),
+      },
+      { projection: { _id: 1 } }
+    );
+  if (existing) {
+    console.log(JSON.stringify({ id: existing._id.toString(), existed: true }, null, 2));
+    await mongoose.disconnect();
+    return;
+  }
+  const doc = {
+    assetId: new mongoose.Types.ObjectId(assetId!),
+    hostId: new mongoose.Types.ObjectId(host!),
+    pricing: { baseDailyCents: 4500, minHours: 1, depositCents: 10000, feeCents: 500 },
+    instantBook: false,
+    blackouts: [],
+    cancellationPolicy: "moderate",
+    status: "active",
+  };
+  const r = await db.collection("listings").insertOne(doc);
+  console.log(JSON.stringify({ id: r.insertedId.toString(), existed: false }, null, 2));
+  await mongoose.disconnect();
+}
+
+async function cmdPreview() {
+  const listing = arg("listing");
+  const start = arg("start");
+  const end = arg("end");
+  if (!isId24(listing)) throw new Error("Missing/invalid --listing (24 hex)");
+  if (!start || !end) throw new Error("Missing --start/--end");
+  const out = await http("POST", "/quotes/preview", { listingId: listing, start, end });
+  console.log(JSON.stringify(out, null, 2));
+}
+
+async function cmdBook() {
+  const as: Role = (arg("as") as Role) || "renter";
+  const sess = readSession();
+  const token = sess[as]?.token;
+  if (!token) throw new Error(`No session for role ${as}. Login first.`);
+  const listing = arg("listing");
+  const start = arg("start");
+  const end = arg("end");
+  if (!isId24(listing)) throw new Error("Missing/invalid --listing (24 hex)");
+  if (!start || !end) throw new Error("Missing --start/--end");
+  const out = await http("POST", "/bookings", { listingId: listing, start, end }, token);
+  console.log(JSON.stringify(out, null, 2));
+}
+
+async function cmdBookingsList() {
+  const as: Role = (arg("as") as Role) || "renter";
+  const state = arg("state"); // pending|accepted|declined|cancelled (your enum)
+  const sess = readSession();
+  const token = sess[as]?.token;
+  if (!token) throw new Error(`No session for role ${as}. Login first.`);
+  const qp = state ? `?state=${encodeURIComponent(state)}` : "";
+  const out = await http("GET", `/bookings${qp}`, undefined, token);
+  console.log(JSON.stringify(out, null, 2));
+}
+
+async function cmdBookingsAccept() {
+  const as: Role = (arg("as") as Role) || "host";
+  const sess = readSession();
+  const token = sess[as]?.token;
+  if (!token) throw new Error(`No session for role ${as}. Login first.`);
+  const id = arg("id");
+  if (!isId24(id)) throw new Error("Missing/invalid --id (booking id)");
+  const out = await http("POST", `/bookings/${id}/accept`, undefined, token);
+  console.log(JSON.stringify(out, null, 2));
+}
+
+async function cmdLocksClear() {
+  const listing = arg("listing");
+  if (!isId24(listing)) throw new Error("Missing/invalid --listing");
+  await mongoose.connect(process.env.MONGO_URI as string);
+  const db = mongoose.connection.db!;
+  const r = await db
+    .collection("bookinglocks")
+    .deleteMany({ listingId: new mongoose.Types.ObjectId(listing) });
+  console.log(JSON.stringify({ deleted: r.deletedCount }, null, 2));
+  await mongoose.disconnect();
+}
+
+async function main() {
+  const cmd = process.argv[2];
+  try {
+    switch (cmd) {
+      case "health":
+        await cmdHealth();
+        break;
+      case "login":
+        await cmdLogin();
+        break;
+      case "me":
+        await cmdMe();
+        break;
+      case "asset:create":
+        await cmdAssetCreate();
+        break;
+      case "listing:ensure":
+        await cmdListingEnsure();
+        break;
+      case "preview":
+        await cmdPreview();
+        break;
+      case "book":
+        await cmdBook();
+        break;
+      case "bookings:list":
+        await cmdBookingsList();
+        break;
+      case "bookings:accept":
+        await cmdBookingsAccept();
+        break;
+      case "locks:clear":
+        await cmdLocksClear();
+        break;
+      default:
+        console.log(
+          `Usage (examples):
+  npm run cli -- health
+  npm run cli -- login --email ava5@example.com --as renter
+  npm run cli -- login --email ava6@example.com --as host
+  npm run cli -- me --as host
+
+  npm run cli -- asset:create --as host --category car --title "Civic LX" --lng -95.9345 --lat 41.2565
+  npm run cli -- listing:ensure --asset <ASSET_ID>     # host id auto-detected from host session
+
+  # time format must be ISO UTC, e.g. 2025-09-15T05:00:00Z
+  npm run cli -- preview --listing <LID> --start <ISO> --end <ISO>
+
+  npm run cli -- book --as renter --listing <LID> --start <ISO> --end <ISO>
+  npm run cli -- bookings:list --as renter --state pending
+  npm run cli -- bookings:list --as host   --state pending
+  npm run cli -- bookings:accept --as host --id <BID>
+
+  npm run cli -- locks:clear --listing <LID>
+`
+        );
+    }
+  } catch (e: any) {
+    const out = { ok: false, error: e?.message || String(e), status: e?.status, body: e?.body };
+    console.error(JSON.stringify(out, null, 2));
+    process.exit(1);
+  }
+}
+main();

--- a/server/src/modules/assets/routes.ts
+++ b/server/src/modules/assets/routes.ts
@@ -10,7 +10,7 @@ const router = Router();
 
 /** Host: create an asset (location required) */
 router.post(
-  "/assets",
+  "/",
   requireAuth,
   requireRole("host"),
   asyncHandler(async (req, res) => {
@@ -18,11 +18,9 @@ router.post(
     const parsed = CreateAssetSchema.safeParse(req.body);
     if (!parsed.success) {
       const details = parsed.error.flatten();
-      return res
-        .status(422)
-        .json({
-          error: { code: "UNPROCESSABLE_ENTITY", message: "Invalid request body", details },
-        });
+      return res.status(422).json({
+        error: { code: "UNPROCESSABLE_ENTITY", message: "Invalid request body", details },
+      });
     }
     const input = CreateAssetSchema.parse(req.body) as CreateAssetInput;
     const { userId } = getAuth(req);

--- a/server/src/modules/bookings/model.ts
+++ b/server/src/modules/bookings/model.ts
@@ -162,9 +162,11 @@ BookingSchema.pre("validate", function (next) {
 });
 
 /** Range + dashboards */
-BookingSchema.index({ listingId: 1, start: 1, end: 1 });
-BookingSchema.index({ hostId: 1, state: 1 });
-BookingSchema.index({ renterId: 1, state: 1 });
+// Efficient role/state queries
+BookingSchema.index({ renterId: 1, state: 1, start: 1 });
+BookingSchema.index({ hostId: 1, state: 1, start: 1 });
+// For availability/calendar views
+BookingSchema.index({ listingId: 1, start: 1 });
 
 export const Booking: Model<BookingDoc> =
   mongoose.models.Booking || mongoose.model<BookingDoc>("Booking", BookingSchema);

--- a/server/src/modules/bookings/routes.ts
+++ b/server/src/modules/bookings/routes.ts
@@ -1,0 +1,108 @@
+// src/modules/bookings/routes.ts
+import { Router } from "express";
+import { z } from "zod/v4";
+
+import {
+  createBooking,
+  listBookings,
+  acceptBooking,
+  declineBooking,
+  cancelPendingBooking,
+} from "./service.js";
+import { requireAuth, requireRole, getAuth } from "../../middlewares/auth.js";
+import { asyncHandler, jsonOk } from "../../utils/http.js";
+
+const router = Router();
+
+const CreateSchema = z.object({
+  listingId: z.string().length(24),
+  start: z.coerce.date(),
+  end: z.coerce.date(),
+});
+
+router.post(
+  "/",
+  requireAuth,
+  requireRole("renter"),
+  asyncHandler(async (req, res) => {
+    const { userId } = getAuth(req);
+    const { listingId, start, end } = CreateSchema.parse(req.body);
+
+    const doc = await createBooking({ renterId: userId, listingId, start, end });
+    jsonOk(res, {
+      id: doc.id,
+      state: doc.state,
+      start: doc.start,
+      end: doc.end,
+      granularity: doc.granularity,
+      pricingSnapshot: doc.pricingSnapshot,
+    });
+  })
+);
+
+const ListQuery = z.object({
+  state: z.enum(["pending", "accepted", "declined", "cancelled"]).optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(50).default(20),
+  // Optional override: admin could pass role=renter|host; for normal users we derive from current role.
+  role: z.enum(["renter", "host"]).optional(),
+});
+
+router.get(
+  "/",
+  requireAuth,
+  asyncHandler(async (req, res) => {
+    const { userId, role: myRole } = getAuth(req);
+    const q = ListQuery.parse(req.query);
+    const role = q.role ?? myRole; // non-admins just use their own role
+
+    const out = await listBookings({
+      userId,
+      role: role === "host" ? "host" : "renter",
+      state: q.state,
+      page: q.page,
+      limit: q.limit,
+    });
+    jsonOk(res, out);
+  })
+);
+
+const IdParam = z.object({ id: z.string().length(24) });
+
+router.post(
+  "/:id/accept",
+  requireAuth,
+  requireRole("host"),
+  asyncHandler(async (req, res) => {
+    const { id } = IdParam.parse(req.params);
+    const { userId } = getAuth(req);
+    const doc = await acceptBooking(userId, id);
+    jsonOk(res, { id: doc.id, state: doc.state });
+  })
+);
+
+router.post(
+  "/:id/decline",
+  requireAuth,
+  requireRole("host"),
+  asyncHandler(async (req, res) => {
+    const { id } = IdParam.parse(req.params);
+    const { userId } = getAuth(req);
+    const doc = await declineBooking(userId, id);
+    jsonOk(res, { id: doc.id, state: doc.state });
+  })
+);
+
+router.post(
+  "/:id/cancel",
+  requireAuth,
+  requireRole("renter"),
+  asyncHandler(async (req, res) => {
+    const { id } = IdParam.parse(req.params);
+    const { userId } = getAuth(req);
+    const doc = await cancelPendingBooking(userId, id);
+    jsonOk(res, { id: doc.id, state: doc.state });
+  })
+);
+
+export default router;

--- a/server/src/modules/bookings/service.ts
+++ b/server/src/modules/bookings/service.ts
@@ -1,113 +1,270 @@
+// src/modules/bookings/service.ts
 import mongoose from "mongoose";
 
-import { Booking, type BookingDoc, type Granularity, type BookingState } from "./model.js";
-import { connectMongo } from "../../config/db.js";
+import { Booking, type BookingDoc } from "./model.js";
+import { toUtcMidnight, enumerateBuckets } from "../../utils/dates.js";
 import { Listing } from "../listings/model.js";
+import { BookingLock } from "../locks/model.js";
+import { lockBuckets, unlockBuckets } from "../locks/service.js";
 
-export type PricingSnapshot = {
-  currency?: string;
-  baseCents: number;
-  feeCents?: number;
-  taxCents?: number;
-  depositCents?: number;
-  totalCents: number;
-  lineItems?: Array<{ code: string; label: string; amountCents: number }>;
-};
+type Granularity = "hour" | "day";
+const HOUR_CATS = new Set(["car", "boat", "jetski"]);
 
-export type CreateBookingInput = {
-  listingId: string;
+function overlaps(aStart: Date, aEnd: Date, bStart: Date, bEnd: Date) {
+  return aStart < bEnd && bStart < aEnd;
+}
+
+function buildBucketsFromBooking(b: BookingDoc): string[] {
+  const s = b.granularity === "hour" ? b.start.getTime() : toUtcMidnight(b.start).getTime();
+  const e = b.granularity === "hour" ? b.end.getTime() : toUtcMidnight(b.end).getTime();
+  return enumerateBuckets(s, e, b.granularity);
+}
+
+async function getCategory(listing: any): Promise<string> {
+  if (!mongoose.connection.db) throw new Error("DB not ready");
+  const asset = await mongoose.connection.db
+    .collection("assets")
+    .findOne({ _id: listing.assetId }, { projection: { category: 1 } });
+  return asset?.category || "misc";
+}
+
+// Decide granularity using pricing OR asset category
+async function resolveGranularity(listing: any): Promise<Granularity> {
+  if (listing?.pricing?.baseHourlyCents) return "hour";
+
+  // fetch asset category to infer hourly categories
+  if (!mongoose.connection.db) throw new Error("DB not ready");
+  const asset = await mongoose.connection.db
+    .collection("assets")
+    .findOne({ _id: listing.assetId }, { projection: { category: 1 } });
+
+  return HOUR_CATS.has(asset?.category) ? "hour" : "day";
+}
+
+// Build buckets after we know the granularity
+async function buildBucketsAndGranularity(listing: any, start: Date, end: Date) {
+  const category = await getCategory(listing);
+  const granularity: Granularity = HOUR_CATS.has(category) ? "hour" : "day";
+  const s = start.getTime();
+  const e = end.getTime();
+  const buckets = enumerateBuckets(s, e, granularity);
+  return { granularity, buckets };
+}
+
+function priceSnapshotByDays(listing: any, start: Date, end: Date) {
+  const p = listing?.pricing || {};
+  const feeCents = p.feeCents ?? 0;
+  const depositCents = p.depositCents ?? 0;
+  const taxCents = 0;
+
+  const daily =
+    (p.baseDailyCents as number | undefined) ??
+    ((p.baseHourlyCents as number | undefined) ?? 0) * 24;
+  if (!daily)
+    throw Object.assign(new Error("Missing daily/hourly pricing"), { code: "NO_PRICING" });
+
+  const durationMs = end.getTime() - start.getTime();
+  const billableDays = Math.max(1, Math.ceil(durationMs / (24 * 3600 * 1000)));
+
+  const baseCents = billableDays * daily;
+  const totalCents = baseCents + feeCents + taxCents;
+
+  return {
+    nUnits: billableDays, // you can keep hours here if you prefer, but days is clearer for billing
+    pricingSnapshot: { baseCents, feeCents, depositCents, taxCents, totalCents },
+  };
+}
+
+async function assertAvailable(
+  listing: any,
+  start: Date,
+  end: Date,
+  granularity: Granularity,
+  buckets: string[]
+) {
+  if (!buckets.length) {
+    throw Object.assign(new Error("Empty or invalid time window"), { code: "INVALID_WINDOW" });
+  }
+
+  // Locks conflict?
+  const lockDocs = await BookingLock.find(
+    { listingId: listing._id, dateBucket: { $in: buckets } },
+    { dateBucket: 1, _id: 0 }
+  ).lean();
+
+  // Blackouts conflict?
+  const blackoutHits =
+    (listing.blackouts || []).filter((b: any) =>
+      overlaps(start, end, new Date(b.start), new Date(b.end))
+    ) || [];
+
+  if (lockDocs.length || blackoutHits.length) {
+    const err: any = new Error("Requested window is unavailable");
+    err.code = "UNAVAILABLE";
+    err.conflictBuckets = lockDocs.map((d) => d.dateBucket);
+    err.conflictBlackouts = blackoutHits.map((b: any) => ({
+      start: b.start,
+      end: b.end,
+      reason: b.reason,
+    }));
+    throw err;
+  }
+}
+
+/** Create booking (pending or confirmed if instantBook). Locks are acquired; on failure we roll back the booking. */
+export async function createBooking(args: {
   renterId: string;
-  start: Date | string | number; // ISO or ms ok
-  end: Date | string | number;
-  granularity: Granularity;
-  pricingSnapshot: PricingSnapshot;
-  instant?: boolean; // if true => state "accepted"
-  locks?: Array<{ lockId: string; dateBucket: string }>;
-};
+  listingId: string;
+  start: Date;
+  end: Date;
+  // optional knobs for later (protection plan, promoCode, etc.)
+}) {
+  const { renterId, listingId, start, end } = args;
 
-export async function createBookingPending(input: CreateBookingInput): Promise<BookingDoc> {
-  await connectMongo();
+  if (!mongoose.isValidObjectId(listingId)) {
+    throw Object.assign(new Error("Invalid listingId"), { code: "INVALID_ID" });
+  }
+  if (end <= start) {
+    throw Object.assign(new Error("end must be after start"), { code: "INVALID_WINDOW" });
+  }
+  // Limit absurdly large range (31d)
+  if (end.getTime() - start.getTime() > 31 * 24 * 3600 * 1000) {
+    throw Object.assign(new Error("range too large"), { code: "INVALID_WINDOW" });
+  }
 
-  const listing = await Listing.findById(input.listingId).lean();
-  if (!listing) {
+  const listing = await Listing.findById(listingId).lean();
+  if (!listing || listing.status !== "active") {
     throw Object.assign(new Error("Listing not found"), { code: "LISTING_NOT_FOUND" });
   }
 
-  const doc = new Booking({
-    listingId: new mongoose.Types.ObjectId(input.listingId),
-    assetId: new mongoose.Types.ObjectId(String((listing as any).assetId)),
-    hostId: new mongoose.Types.ObjectId(String((listing as any).hostId)),
-    renterId: new mongoose.Types.ObjectId(input.renterId),
+  const { granularity, buckets } = await buildBucketsAndGranularity(listing, start, end);
+  await assertAvailable(listing, start, end, granularity, buckets);
 
-    start: new Date(input.start),
-    end: new Date(input.end),
-    granularity: input.granularity,
+  const { nUnits, pricingSnapshot } = priceSnapshotByDays(listing, start, end);
 
-    pricingSnapshot: {
-      currency: input.pricingSnapshot.currency ?? "USD",
-      baseCents: input.pricingSnapshot.baseCents,
-      feeCents: input.pricingSnapshot.feeCents ?? 0,
-      taxCents: input.pricingSnapshot.taxCents ?? 0,
-      depositCents: input.pricingSnapshot.depositCents ?? 0,
-      totalCents: input.pricingSnapshot.totalCents,
-      lineItems: input.pricingSnapshot.lineItems ?? [],
-    },
-
-    state: input.instant ? ("accepted" as BookingState) : ("pending" as BookingState),
-
-    locks: (input.locks ?? []).map((l) => ({
-      lockId: new mongoose.Types.ObjectId(l.lockId),
-      dateBucket: l.dateBucket,
-    })),
+  // Create booking doc first to have an id for the lock reason.
+  const doc = await Booking.create({
+    renterId: new mongoose.Types.ObjectId(renterId),
+    hostId: listing.hostId,
+    listingId: listing._id,
+    assetId: listing.assetId,
+    start,
+    end,
+    granularity,
+    pricingSnapshot,
+    state: listing.instantBook ? "accepted" : "pending",
   } as Partial<BookingDoc>);
 
-  await doc.save();
+  try {
+    await lockBuckets({
+      listingId: String(listing._id),
+      buckets,
+      granularity,
+      reason: `booking:${doc._id.toString()}`,
+    });
+  } catch (e: any) {
+    // On lock conflict, delete the just-created booking to avoid orphaned docs.
+    await Booking.deleteOne({ _id: doc._id }).catch(() => {});
+    if (e?.code === "LOCK_CONFLICT") {
+      const err: any = new Error("Requested window is unavailable");
+      err.code = "UNAVAILABLE";
+      throw err;
+    }
+    throw e;
+  }
+
   return doc;
 }
 
-export async function findBookingById(id: string): Promise<BookingDoc | null> {
-  await connectMongo();
-  return Booking.findById(id).exec();
+/** Host accepts a pending booking → confirmed (keeps locks). */
+export async function acceptBooking(hostId: string, bookingId: string) {
+  if (!mongoose.isValidObjectId(bookingId)) {
+    throw Object.assign(new Error("Invalid booking id"), { code: "INVALID_ID" });
+  }
+  const b = await Booking.findById(bookingId);
+  if (!b) throw Object.assign(new Error("Not found"), { code: "NOT_FOUND", status: 404 });
+  if (String(b.hostId) !== hostId)
+    throw Object.assign(new Error("Forbidden"), { code: "FORBIDDEN", status: 403 });
+  if (b.state !== "pending")
+    throw Object.assign(new Error("Invalid state"), { code: "INVALID_STATE", status: 409 });
+
+  b.state = "accepted";
+  await b.save();
+  return b;
 }
 
-export async function getBookingsByRole(
-  userId: string,
-  role: "host" | "renter",
-  state?: BookingState
-): Promise<BookingDoc[]> {
-  await connectMongo();
+/** Host declines a pending booking → declined (unlock buckets). */
+export async function declineBooking(hostId: string, bookingId: string) {
+  if (!mongoose.isValidObjectId(bookingId)) {
+    throw Object.assign(new Error("Invalid booking id"), { code: "INVALID_ID" });
+  }
+  const b = await Booking.findById(bookingId);
+  if (!b) throw Object.assign(new Error("Not found"), { code: "NOT_FOUND", status: 404 });
+  if (String(b.hostId) !== hostId)
+    throw Object.assign(new Error("Forbidden"), { code: "FORBIDDEN", status: 403 });
+  if (b.state !== "pending")
+    throw Object.assign(new Error("Invalid state"), { code: "INVALID_STATE", status: 409 });
+
+  const buckets = buildBucketsFromBooking(b);
+  await unlockBuckets(String(b.listingId), buckets);
+  b.state = "declined";
+  await b.save();
+  return b;
+}
+
+/** Renter cancels a pending booking → cancelled (unlock buckets). */
+export async function cancelPendingBooking(renterId: string, bookingId: string) {
+  if (!mongoose.isValidObjectId(bookingId)) {
+    throw Object.assign(new Error("Invalid booking id"), { code: "INVALID_ID" });
+  }
+  const b = await Booking.findById(bookingId);
+  if (!b) throw Object.assign(new Error("Not found"), { code: "NOT_FOUND", status: 404 });
+  if (String(b.renterId) !== renterId)
+    throw Object.assign(new Error("Forbidden"), { code: "FORBIDDEN", status: 403 });
+  if (b.state !== "pending")
+    throw Object.assign(new Error("Invalid state"), { code: "INVALID_STATE", status: 409 });
+
+  const buckets = buildBucketsFromBooking(b);
+  await unlockBuckets(String(b.listingId), buckets);
+  b.state = "cancelled";
+  await b.save();
+  return b;
+}
+
+/** List bookings by role/state with simple pagination */
+// src/modules/bookings/service.ts
+export async function listBookings(opts: {
+  userId: string;
+  role: "renter" | "host";
+  state?: "draft" | "pending" | "accepted" | "declined" | "cancelled" | "in_progress" | "completed"; // <-- match your schema words
+  page?: number;
+  limit?: number;
+}) {
+  const { userId, role, state, page = 1, limit = 20 } = opts;
+
   const q: any =
-    role === "host"
-      ? { hostId: new mongoose.Types.ObjectId(userId) }
-      : { renterId: new mongoose.Types.ObjectId(userId) };
+    role === "renter"
+      ? { renterId: new mongoose.Types.ObjectId(userId) }
+      : { hostId: new mongoose.Types.ObjectId(userId) };
   if (state) q.state = state;
-  return Booking.find(q).sort({ createdAt: -1 }).exec();
-}
 
-export async function cancelBooking(id: string, actorId: string): Promise<BookingDoc | null> {
-  await connectMongo();
-  // For now, simple transition. Unlocking handled in C7.
-  return Booking.findByIdAndUpdate(
-    id,
-    { $set: { state: "cancelled" as BookingState } },
-    { new: true }
-  ).exec();
-}
+  const raw = await Booking.find(q)
+    .sort({ start: 1 })
+    .skip((page - 1) * limit)
+    .limit(limit)
+    .lean();
 
-/** Public shape for API responses */
-export function toPublicBooking(b: BookingDoc) {
-  return {
-    id: b.id,
-    listingId: b.listingId.toString(),
-    assetId: b.assetId.toString(),
-    hostId: b.hostId.toString(),
-    renterId: b.renterId.toString(),
+  const items = raw.map((b: any) => ({
+    id: String(b._id),
+    state: b.state,
     start: b.start,
     end: b.end,
     granularity: b.granularity,
+    listingId: String(b.listingId),
+    renterId: String(b.renterId),
+    hostId: String(b.hostId),
     pricingSnapshot: b.pricingSnapshot,
-    state: b.state,
-    createdAt: b.createdAt,
-    updatedAt: b.updatedAt,
-  };
+  }));
+
+  return { page, limit, items, hasMore: raw.length === limit };
 }

--- a/server/src/modules/quotes/routes.ts
+++ b/server/src/modules/quotes/routes.ts
@@ -3,7 +3,7 @@ import { Router } from "express";
 import mongoose from "mongoose";
 import { z } from "zod";
 
-import { enumerateBuckets, toUtcMidnight } from "../../utils/dates.js";
+import { enumerateBuckets } from "../../utils/dates.js";
 import { asyncHandler } from "../../utils/http.js";
 import { Listing } from "../listings/model.js";
 import { BookingLock } from "../locks/model.js";
@@ -20,39 +20,47 @@ function overlaps(aStart: Date, aEnd: Date, bStart: Date, bEnd: Date) {
   return aStart < bEnd && bStart < aEnd;
 }
 
+// Categories that allow hour-based selection (but still bill by full days)
+const HOUR_CATS = new Set(["car", "boat", "jetski"]);
+
 router.post(
-  "/quotes/preview",
+  "/preview",
   asyncHandler(async (req, res) => {
     const { listingId, start, end } = PreviewSchema.parse(req.body);
+
+    if (end <= start) {
+      return res
+        .status(422)
+        .json({ error: { code: "INVALID_WINDOW", message: "end must be after start" } });
+    }
 
     const listing = await Listing.findById(listingId).lean();
     if (!listing || listing.status !== "active") {
       return res.status(404).json({ error: { code: "LISTING_NOT_FOUND" } });
     }
 
-    // Decide granularity
-    const hasHourly = !!listing.pricing?.baseHourlyCents;
-    const granularity: "hour" | "day" = hasHourly ? "hour" : "day";
+    // Look up asset category to decide granularity (selection granularity, not billing)
+    if (!mongoose.connection.db) throw new Error("DB not ready");
+    const asset = await mongoose.connection.db
+      .collection("assets")
+      .findOne({ _id: listing.assetId }, { projection: { category: 1 } });
 
-    // Build requested buckets
-    const buckets =
-      granularity === "hour"
-        ? enumerateBuckets(start.getTime(), end.getTime(), "hour")
-        : enumerateBuckets(toUtcMidnight(start).getTime(), toUtcMidnight(end).getTime(), "day");
+    const category = asset?.category || "misc";
+    const granularity: "hour" | "day" = HOUR_CATS.has(category) ? "hour" : "day";
 
+    // Build requested buckets for availability/locks
+    const buckets = enumerateBuckets(start.getTime(), end.getTime(), granularity);
     if (!buckets.length) {
-      return res.status(422).json({
-        error: { code: "INVALID_WINDOW", message: "Empty or invalid time window" },
-      });
+      return res
+        .status(422)
+        .json({ error: { code: "INVALID_WINDOW", message: "Empty or invalid time window" } });
     }
 
     // 1) Locks conflict?
-    const lockDocs = await BookingLock.find({
-      listingId: new mongoose.Types.ObjectId(listingId),
-      dateBucket: { $in: buckets },
-    })
-      .select({ dateBucket: 1 })
-      .lean();
+    const lockDocs = await BookingLock.find(
+      { listingId: new mongoose.Types.ObjectId(listingId), dateBucket: { $in: buckets } },
+      { dateBucket: 1, _id: 0 }
+    ).lean();
 
     // 2) Blackouts conflict?
     const blackoutHits =
@@ -75,46 +83,46 @@ router.post(
       });
     }
 
-    // Pricing
-    const p = listing.pricing || {};
+    // --- Pricing ---
+    // For hour categories, bill by whole days (ceil) even though selection is hourly.
+    // For day categories, bill per-day based on number of day buckets.
+    const p = (listing as any).pricing || {};
     const feeCents = p.feeCents ?? 0;
     const depositCents = p.depositCents ?? 0;
 
+    const daily =
+      (p.baseDailyCents as number | undefined) ??
+      ((p.baseHourlyCents as number | undefined) ?? 0) * 24;
+
+    if (!daily) {
+      return res
+        .status(422)
+        .json({ error: { code: "NO_PRICING", message: "Missing daily/hourly pricing" } });
+    }
+
     let nUnits = buckets.length;
     let baseCents = 0;
+    let billableDays: number | undefined;
 
     if (granularity === "hour") {
-      const minHours = p.minHours ?? 1;
-      const hourly = p.baseHourlyCents ?? Math.ceil(((p.baseDailyCents ?? 0) as number) / 24);
-
-      if (!hourly) {
-        return res.status(422).json({
-          error: { code: "NO_PRICING", message: "Missing hourly/daily pricing" },
-        });
-      }
-
-      const billable = Math.max(nUnits, minHours);
-      baseCents = hourly * billable;
-      nUnits = billable; // reflect the billable hours in the response
+      const durationMs = end.getTime() - start.getTime();
+      billableDays = Math.max(1, Math.ceil(durationMs / (24 * 3600 * 1000)));
+      baseCents = daily * billableDays;
     } else {
-      const daily = p.baseDailyCents ?? Math.ceil(((p.baseHourlyCents ?? 0) as number) * 24);
-      if (!daily) {
-        return res.status(422).json({
-          error: { code: "NO_PRICING", message: "Missing daily/hourly pricing" },
-        });
-      }
+      // day-based search & day-based billing
       baseCents = daily * nUnits;
     }
 
-    const taxCents = 0; // tax comes later (C7)
+    const taxCents = 0; // tax later (C7)
     const totalCents = baseCents + feeCents + taxCents;
 
     return res.json({
       listingId,
-      start,
-      end,
-      granularity,
-      nUnits,
+      start: start.toISOString(),
+      end: end.toISOString(),
+      granularity, // 'hour' for car/boat/jetski; 'day' otherwise
+      nUnits, // availability buckets count (hours or days)
+      ...(billableDays ? { billableDays } : {}),
       pricingSnapshot: {
         baseCents,
         feeCents,

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -7,6 +7,7 @@ import { pingRedis } from "./config/redis.js";
 import adminRouter from "./modules/admin/routes.js";
 import assetsRouter from "./modules/assets/routes.js";
 import authRouter from "./modules/auth/routes.js";
+import bookingsRouter from "./modules/bookings/routes.js";
 import listingsRouter from "./modules/listings/routes.js";
 import quotesRouter from "./modules/quotes/routes.js";
 import searchRouter from "./modules/search/routes.js";
@@ -18,11 +19,12 @@ export const router = Router();
 
 // Feature mounts
 router.use("/auth", authRouter);
-router.use("/", usersRouter); // e.g., GET /me
-router.use("/", assetsRouter); // defines /assets
+router.use("/bookings", bookingsRouter);
+router.use("/assets", assetsRouter); // defines /assets
 router.use("/search", searchRouter); // GET /search
 router.use("/quotes", quotesRouter); // POST /quotes/preview
 router.use("/listings", listingsRouter); // GET /listings/:id/availability
+router.use("/users", usersRouter); // e.g., GET /me
 router.use("/admin", adminRouter);
 
 // KYC


### PR DESCRIPTION
…; stabilize bookings flow

- scripts/cli.ts with login, asset:create, listing:ensure, preview, book, bookings:list/accept, locks:clear
- package.json scripts (npm run cli)
- standardize listing/day-vs-hour preview: hourly window but day-min billing
- booking service: ensure assetId set, state transitions (pending→accepted), list filters by role/state
- routes wiring: bookings + quotes mounted consistently
- add .gitignore for server/tmp session cache