### PR TITLE
feat(pricing): finalize C8 — taxes, promos, calculator parity, guards…

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -32,3 +32,7 @@ S3_KEY_PREFIX=fr          # optional (defaults to "fr" if omitted)
 # Stripe (test mode)
 STRIPE_SECRET_KEY=sk_test_xxx
 STRIPE_WEBHOOK_SECRET=whsec_xxx
+
+TAX_RATE_MAP=NE:7.5,TX:8.25
+TAX_RATE_PCT=8.25
+PROMOS=SAVE10:percent:10|label=Spring Sale;FLAT5:flat:500|label=$5 off

--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,7 @@
     "db:sync-indexes": "tsx scripts/sync-indexes.ts",
     "cli": "tsx scripts/cli.ts",
     "c7": "tsx scripts/c7.ts",
+    "backfill": "tsx scripts/backfill/listing_point_from_asset.ts",
     "test:health": "npm run cli -- health"
   },
   "keywords": [],

--- a/server/scripts/backfill/listing_point_from_asset.ts
+++ b/server/scripts/backfill/listing_point_from_asset.ts
@@ -1,0 +1,51 @@
+import "dotenv/config";
+import mongoose from "mongoose";
+
+async function run() {
+  const uri = process.env.MONGO_URI!;
+  if (!uri) throw new Error("MONGO_URI missing");
+
+  await mongoose.connect(uri);
+  const db = mongoose.connection.db!;
+  const listings = db.collection("listings");
+  const assets = db.collection("assets");
+
+  // Find listings missing a location.point
+  const cursor = listings.find(
+    { $or: [{ location: { $exists: false } }, { "location.point": { $exists: false } }] },
+    { projection: { _id: 1, assetId: 1, location: 1 } }
+  );
+
+  let scanned = 0;
+  let updated = 0;
+
+  while (await cursor.hasNext()) {
+    const l = await cursor.next();
+    if (!l) break;
+    scanned++;
+
+    const assetId = l.assetId;
+    if (!assetId) continue;
+
+    const a = await assets.findOne({ _id: assetId }, { projection: { location: 1 } });
+
+    const point = (a as any)?.location;
+    if (
+      point &&
+      point.type === "Point" &&
+      Array.isArray(point.coordinates) &&
+      point.coordinates.length === 2
+    ) {
+      const res = await listings.updateOne({ _id: l._id }, { $set: { "location.point": point } });
+      if (res.modifiedCount) updated++;
+    }
+  }
+
+  console.log(JSON.stringify({ scanned, updated }, null, 2));
+  await mongoose.disconnect();
+}
+
+run().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/server/src/modules/bookings/model.ts
+++ b/server/src/modules/bookings/model.ts
@@ -23,15 +23,27 @@ const LineItemSchema = new Schema(
 );
 
 /** Immutable pricing snapshot at time of booking/quote. */
+// src/modules/bookings/model.ts
+// (inside your PricingSnapshot sub-schema)
 const PricingSnapshotSchema = new Schema(
   {
-    currency: { type: String, default: "USD" },
-    baseCents: { type: Number, required: true, min: 0 },
-    feeCents: { type: Number, default: 0, min: 0 },
-    taxCents: { type: Number, default: 0, min: 0 },
-    depositCents: { type: Number, default: 0, min: 0 },
-    totalCents: { type: Number, required: true, min: 0 },
-    lineItems: { type: [LineItemSchema], default: [] },
+    currency: { type: String, required: true },
+    totalCents: { type: Number, required: true },
+
+    // C8 additions
+    baseCents: { type: Number },
+    feeCents: { type: Number },
+    discountCents: { type: Number },
+    taxCents: { type: Number },
+    depositCents: { type: Number },
+    promoCode: { type: String, default: null },
+    lineItems: [
+      {
+        code: { type: String, enum: ["BASE", "FEE", "PROMO", "TAX"], required: true },
+        label: { type: String, required: true },
+        amountCents: { type: Number, required: true },
+      },
+    ],
   },
   { _id: false }
 );

--- a/server/src/modules/listings/model.ts
+++ b/server/src/modules/listings/model.ts
@@ -2,6 +2,38 @@ import mongoose, { Schema, type Model } from "mongoose";
 
 import type { CancellationPolicy, ListingStatus } from "../../domain/index.js";
 
+/** GeoJSON Point (WGS84). Store as [lng, lat]. */
+const GeoPointSchema = new Schema(
+  {
+    type: { type: String, enum: ["Point"], default: "Point", required: true },
+    coordinates: {
+      type: [Number], // [lng, lat]
+      validate: {
+        validator: (v: number[]) => Array.isArray(v) && v.length === 2,
+        message: "coordinates must be [lng, lat]",
+      },
+      required: true,
+    },
+  },
+  { _id: false }
+);
+
+/** Minimal location for taxation + future geo */
+const ListingLocationSchema = new Schema(
+  {
+    point: { type: GeoPointSchema, required: false }, // optional; may mirror asset.location
+    state: {
+      type: String,
+      minlength: 2,
+      maxlength: 2,
+      uppercase: true,
+      trim: true,
+      required: false, // required only when status is 'active' (see pre-validate)
+    },
+  },
+  { _id: false }
+);
+
 /** Pricing (all integer cents). Either daily or hourly must be provided. */
 const PricingSchema = new Schema(
   {
@@ -36,6 +68,12 @@ export interface ListingDoc extends mongoose.Document {
     feeCents: number;
   };
 
+  /** Minimal location for taxes + geo */
+  location?: {
+    point?: { type: "Point"; coordinates: [number, number] }; // [lng, lat]
+    state?: string; // "TX", "NE", ...
+  };
+
   instantBook: boolean;
   blackouts: Array<{ start: Date; end: Date; reason?: string }>;
   cancellationPolicy: CancellationPolicy;
@@ -51,6 +89,9 @@ const ListingSchema = new Schema<ListingDoc>(
     hostId: { type: Schema.Types.ObjectId, ref: "User", required: true, index: true },
 
     pricing: { type: PricingSchema, required: true },
+
+    /** NEW: location */
+    location: { type: ListingLocationSchema, required: false },
 
     instantBook: { type: Boolean, default: false },
     blackouts: { type: [BlackoutSchema], default: [] },
@@ -71,17 +112,64 @@ const ListingSchema = new Schema<ListingDoc>(
   { timestamps: true, toJSON: { virtuals: true }, toObject: { virtuals: true } }
 );
 
-/** Validation: require at least one base price (daily or hourly) */
+/** Validation: require at least one base price (daily or hourly) and state for active listings */
 ListingSchema.pre("validate", function (next) {
-  const p = (this as ListingDoc).pricing || ({} as ListingDoc["pricing"]);
+  const doc = this as ListingDoc;
+
+  const p = doc.pricing || ({} as ListingDoc["pricing"]);
   if (p.baseDailyCents == null && p.baseHourlyCents == null) {
     return next(new Error("pricing.baseDailyCents or pricing.baseHourlyCents is required"));
   }
+
+  if (doc.status === "active") {
+    const state = doc.location?.state?.toUpperCase?.();
+    if (!state || state.length !== 2) {
+      return next(new Error("location.state (2-letter) is required for active listings"));
+    }
+    // normalize to uppercase
+    doc.location = { ...(doc.location || {}), state };
+  }
+
   next();
+});
+
+// --- Option A: default listing.location.point from asset on CREATE only ---
+ListingSchema.pre("save", async function (next) {
+  const doc = this as ListingDoc & { isNew: boolean };
+
+  // Only on initial create; never re-sync later
+  if (!doc.isNew) return next();
+
+  // If a point is already provided, respect it
+  if (doc.location?.point) return next();
+
+  try {
+    // Pull asset.location (GeoJSON Point) directly from the collection
+    const col = mongoose.connection.db?.collection("assets");
+    if (!col) return next();
+
+    const raw = await col.findOne({ _id: doc.assetId }, { projection: { location: 1 } });
+
+    const point = (raw as any)?.location;
+    if (
+      point &&
+      point.type === "Point" &&
+      Array.isArray(point.coordinates) &&
+      point.coordinates.length === 2
+    ) {
+      doc.location = { ...(doc.location || {}), point };
+    }
+
+    return next();
+  } catch (err) {
+    return next(err as any);
+  }
 });
 
 /** Helpful compound for host moderation views */
 ListingSchema.index({ hostId: 1, status: 1 });
+/** Geospatial search (future) */
+ListingSchema.index({ "location.point": "2dsphere" });
 
 export const Listing: Model<ListingDoc> =
   mongoose.models.Listing || mongoose.model<ListingDoc>("Listing", ListingSchema);

--- a/server/src/modules/pricing/calc.ts
+++ b/server/src/modules/pricing/calc.ts
@@ -1,0 +1,174 @@
+// server/src/modules/pricing/calc.ts
+import {
+  getEnvPromos,
+  getTaxExemptStates,
+  getTaxRateDefault,
+  getTaxRateMap,
+  getTaxableFee,
+  type PromoDef,
+} from "../../config/env.js"; // <-- fixed path
+import { logger } from "../../config/logger.js";
+import { Listing, type ListingDoc } from "../listings/model.js";
+
+export type Granularity = "hour" | "day";
+
+export type QuoteInput = {
+  listing: ListingDoc;
+  start: Date;
+  end: Date;
+  promoCode?: string | null;
+};
+
+export type LineItem = {
+  code: "BASE" | "FEE" | "PROMO" | "TAX";
+  label: string;
+  amountCents: number; // negative for discounts
+};
+
+export type QuoteResult = {
+  currency: string;
+  granularity: Granularity;
+  nUnits: number; // billing units (days when hour-cats; days when day-cats)
+  baseCents: number;
+  feeCents: number;
+  discountCents: number;
+  taxCents: number;
+  depositCents: number;
+  totalCents: number;
+  lineItems: LineItem[];
+};
+
+// Match your categories used elsewhere
+const HOUR_CATS = new Set<string>(["car", "boat", "jetski"]);
+
+function pickGranularity(category?: string | null): Granularity {
+  if (category && HOUR_CATS.has(category)) return "hour";
+  return "day";
+}
+
+function ceilUnits(ms: number, unitMs: number): number {
+  const raw = Math.ceil(ms / unitMs);
+  return Math.max(1, raw);
+}
+
+function applyPromo(
+  subtotalCents: number,
+  promo?: PromoDef | null
+): { discountCents: number; label?: string } {
+  if (!promo) return { discountCents: 0 };
+  if (promo.kind === "percent") {
+    const calc = Math.floor((subtotalCents * promo.value) / 100);
+    return {
+      discountCents: Math.min(calc, subtotalCents),
+      label: promo.label ?? `${promo.code} (-${promo.value}%)`,
+    };
+  }
+  const calc = Math.floor(promo.value);
+  return {
+    discountCents: Math.min(calc, subtotalCents),
+    label: promo.label ?? `${promo.code} (-$${(promo.value / 100).toFixed(2)})`,
+  };
+}
+
+function findPromo(code?: string | null): PromoDef | null {
+  if (!code) return null;
+  const upper = code.trim().toUpperCase();
+  if (!upper) return null;
+  const found = getEnvPromos().find((p) => p.code === upper && p.enabled);
+  return found ?? null;
+}
+
+function resolveTaxRateForListing(listing: ListingDoc): number {
+  const map = getTaxRateMap();
+  const def = getTaxRateDefault();
+  const exempt = getTaxExemptStates();
+  const state = (listing as any)?.location?.state?.toUpperCase?.();
+  if (state && exempt.has(state)) return 0;
+  if (state && state in map) return map[state];
+  return def || 0;
+}
+
+export async function computeQuote(input: QuoteInput): Promise<QuoteResult> {
+  const { listing, start, end, promoCode } = input;
+
+  if (!listing) throw new Error("LISTING_NOT_FOUND");
+  if (!start || !end || !(start instanceof Date) || !(end instanceof Date) || end <= start) {
+    throw new Error("INVALID_WINDOW");
+  }
+
+  const granularity = pickGranularity((listing as any).category);
+  const dayMs = 24 * 60 * 60 * 1000;
+  const durationMs = end.getTime() - start.getTime();
+
+  // Your pricing model: baseDailyCents OR (baseHourlyCents * 24)
+  const p: any = (listing as any).pricing || {};
+  const daily =
+    (p.baseDailyCents as number | undefined) ??
+    ((p.baseHourlyCents as number | undefined) ?? 0) * 24;
+  if (!daily || daily < 0) throw new Error("NO_PRICING");
+
+  let nUnits = 0;
+  let baseCents = 0;
+
+  if (granularity === "hour") {
+    // selection is hourly, billing is full days (ceil)
+    nUnits = Math.max(1, Math.ceil(durationMs / dayMs)); // billableDays
+    baseCents = nUnits * daily;
+  } else {
+    // day-based selection and billing (ceil to days)
+    nUnits = Math.max(1, Math.ceil(durationMs / dayMs));
+    baseCents = nUnits * daily;
+  }
+
+  const feeCents = Math.max(0, Math.floor(p.feeCents ?? 0));
+  const depositCents = Math.max(0, Math.floor(p.depositCents ?? 0));
+  const currency = p.currency ?? "usd";
+
+  const promo = findPromo(promoCode);
+  const promoBase = baseCents + feeCents;
+  const { discountCents, label: promoLabel } = applyPromo(promoBase, promo);
+
+  const taxableFee = getTaxableFee();
+  const taxableSubtotalCents = baseCents + (taxableFee ? feeCents : 0) - discountCents;
+  const taxRate = resolveTaxRateForListing(listing);
+  const taxCents = Math.max(0, Math.round(taxableSubtotalCents * taxRate));
+
+  const totalCents = baseCents + feeCents - discountCents + taxCents;
+
+  const lineItems: LineItem[] = [
+    { code: "BASE", label: `Base (${nUnits} day${nUnits > 1 ? "s" : ""})`, amountCents: baseCents },
+  ];
+  if (feeCents > 0) lineItems.push({ code: "FEE", label: "Platform fee", amountCents: feeCents });
+  if (discountCents > 0)
+    lineItems.push({ code: "PROMO", label: promoLabel ?? "Promo", amountCents: -discountCents });
+  if (taxCents > 0)
+    lineItems.push({
+      code: "TAX",
+      label: `Tax (${(taxRate * 100).toFixed(2)}%)`,
+      amountCents: taxCents,
+    });
+
+  logger.info("pricing.computeQuote", {
+    listingId: (listing as any)._id?.toString?.(),
+    state: (listing as any)?.location?.state,
+    granularity,
+    nUnits,
+    promoCode: promoCode ?? null,
+    subtotalCents: baseCents + feeCents - discountCents,
+    taxCents,
+    totalCents,
+  });
+
+  return {
+    currency,
+    granularity,
+    nUnits,
+    baseCents,
+    feeCents,
+    discountCents,
+    taxCents,
+    depositCents,
+    totalCents,
+    lineItems,
+  };
+}


### PR DESCRIPTION
…, and logs

Summary
- Ship a single authoritative pricing calculator and wire it into quotes + PI creation + booking parity.
- Add explicit INVALID_PROMO validation and lightweight preview logging for observability.
- Introduce minimal Listing.location (state + optional point) and a create-time default hook.

Key changes
- /quotes/preview
  - Validate promo codes against env registry; unknown => 422 INVALID_PROMO.
  - Delegate pricing to computeQuote (base, fee, promo, tax, total, line items).
  - Log quotes.preview events with {listingId,start,end,granularity,nUnits,promoCode,totalCents}.
- /payments/intents
  - Validate promo codes up-front; unknown => 422 INVALID_PROMO.
  - Use computeQuote for exact PI amount and store promoCode in PI metadata.
  - Idempotency cache key now includes totalCents and promoCode to avoid mismatched reuse.
  - Maintain bucket locking; cancel PI if locks fail (UNAVAILABLE 409).
- bookings/service
  - Recompute via computeQuote on createBooking (Parity Guard).
  - Reject 409 AMOUNT_MISMATCH when PI amount/snapshot differ from recomputation.
- pricing/calc
  - Env-driven promos (percent/flat) with clamp; tax rate from TAX_RATE_MAP/TAX_RATE_PCT with exempt states; TAXABLE_FEE respected.
  - Category-based granularity with hour-cats billed by full days.
  - Itemized line items: BASE, FEE?, PROMO?, TAX?.
- listings/model
  - Add location: { state?: string, point?: GeoJSON Point }.
  - Require location.state (2-letter) when status === 'active'.
  - Add 2dsphere index on location.point.
  - Pre-save hook: on create, default location.point from asset.location if listing omitted a point (no continuous sync).

Env / configuration
- TAX_RATE_PCT (default percent) / TAX_RATE_MAP (per-state) / TAX_EXEMPT_STATES / TAXABLE_FEE / PROMOS
  - Example: TAX_RATE_MAP=NE:7.5,TX:8.25  PROMOS=SAVE10:percent:10|label=Spring Sale;FLAT5:flat:500

API contracts (errors)
- 422 INVALID_PROMO for unknown promo codes (preview, intents)
- 422 INVALID_WINDOW for bad date ranges; 409 UNAVAILABLE on lock conflicts
- 409 AMOUNT_MISMATCH on booking create if totals drift

Observability
- quotes.preview info logs with core fields
- pricing.computeQuote info logs (listingId, state, granularity, nUnits, promoCode, subtotal, tax, total)

Data model / migration
- Non-breaking: location optional for drafts; required only when activating a listing.
- Backfill script (optional) to copy asset.location → listing.location.point for existing listings.

QA (manual)
- Preview with/without promo; verify TAX label reflects listing.location.state (NE vs TX).
- PI create with promo (idempotent); confirm PI; create booking; parity guard passes.
- Flat promo clamp: tiny daily price with FLAT promo ⇒ discount clamped to subtotal; total 0; tax 0.
- Lock conflict surfaces UNAVAILABLE when double-booking same window.

Security & safety
- All totals computed server-side; client-provided amounts ignored.
- Promo registry sourced from env; no host-provided codes.
- No breaking changes to existing endpoints beyond new error code for bad promos.